### PR TITLE
Fixed shop.svg

### DIFF
--- a/assets/themes/shops/shop.svg
+++ b/assets/themes/shops/shop.svg
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
 <g id="hbars">
 <rect x="1" y="6" width="11" height="0.5" style="fill:#ac39ac"/>


### PR DESCRIPTION
Removed 2 zero width no-break spaces that were at the start of the svg, causing it not to display