### PR TITLE
When filtering theme files, be a bit more strict

### DIFF
--- a/scripts/generateLayerOverview.ts
+++ b/scripts/generateLayerOverview.ts
@@ -29,7 +29,7 @@ const layerFiles = ScriptUtils.readDirRecSync("./assets/layers")
         }
     })
 const themeFiles: any[] = ScriptUtils.readDirRecSync("./assets/themes")
-    .filter(path => path.indexOf(".json") > 0)
+    .filter(path => path.endsWith(".json"))
     .filter(path => path.indexOf("license_info.json") < 0)
     .map(path => {
         return JSON.parse(readFileSync(path, "UTF8"));


### PR DESCRIPTION
This fixes a problem that occurs in my personal development setup and should do no harm to others.

Background: I often use vim for editing text files. That editor creates temporary files when editing a text file, i.e. for a file named `some-theme.json` it creates a so-called swap file at `.some-theme.json.swp`. Now when I run `npm run start` the script that picks up the theme files thinks that this swap file is an actual theme file, fails to parse it and throws an error.

I think it's reasonable to check for theme files to end with `.json` instead of just containing this as a substring.