### PR TITLE
Mention supported freeform types in comment

### DIFF
--- a/Customizations/JSON/TagRenderingConfigJson.ts
+++ b/Customizations/JSON/TagRenderingConfigJson.ts
@@ -37,6 +37,7 @@ export interface TagRenderingConfigJson {
         key: string,
         /**
          * The type of the text-field, e.g. 'string', 'nat', 'float', 'date',...
+         * See UI/Input/ValidatedTextField.ts for supported values
          */
         type?: string,
         /**


### PR DESCRIPTION
I came across the "type" parameter for the freeform option and was wondering which values are actually supported there. Took a moment to find that, so I think to save other theme creators some digging, let's mention that at least in a comment pointing them to the location to look it up