### PR TITLE
Add unclassified highways to Sidewalks theme

### DIFF
--- a/assets/themes/sidewalks/sidewalks.json
+++ b/assets/themes/sidewalks/sidewalks.json
@@ -32,6 +32,7 @@
         "osmTags": {
           "or": [
             "highway=residential",
+            "highway=unclassified",
             "highway=tertiary",
             "highway=secondary"
           ]


### PR DESCRIPTION
In the hierarchy, unclassified highways are between residential and tertiary / secondary, which are already considered in the theme.