### PR TITLE
improve alignment of icons

### DIFF
--- a/UI/BigComponents/UserBadge.ts
+++ b/UI/BigComponents/UserBadge.ts
@@ -79,7 +79,7 @@ export default class UserBadge extends Toggle {
                 }
 
                 const settings =
-                    new Link(Svg.gear_svg(),
+                    new Link(Svg.gear,
                         `${user.backend}/user/${encodeURIComponent(user.name)}/account`,
                         true)
 


### PR DESCRIPTION
Hello,

This is a very small change to improve the alignment of the icons in the top right.
I noticed that the alignment was off because the gear icon was in a div.

Now it's not in a div and looks much better.

Before:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/921217/149643216-15b4d896-1724-4959-8b48-aa5a27d6e613.png">


After:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/921217/149643105-d4355bab-47dd-4b59-aa59-8f7eb14e9ed7.png">
