### PR TITLE
Fix duplicate socket in key in charging stations layer

### DIFF
--- a/assets/layers/charging_station/charging_station.json
+++ b/assets/layers/charging_station/charging_station.json
@@ -1377,7 +1377,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:schuko:voltage=230 V",
+          "if": "socket:schuko:voltage=230 V",
           "then": {
             "en": "<b>Schuko wall plug</b> without ground pin (CEE7/4 type F) outputs 230 volt",
             "nl": "<b>Schuko stekker</b> zonder aardingspin (CEE7/4 type F) heeft een spanning van 230 volt"
@@ -1412,7 +1412,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:schuko:current=16 A",
+          "if": "socket:schuko:current=16 A",
           "then": {
             "en": "<b>Schuko wall plug</b> without ground pin (CEE7/4 type F) outputs at most 16 A",
             "nl": "<b>Schuko stekker</b> zonder aardingspin (CEE7/4 type F) levert een stroom van maximaal 16 A"
@@ -1447,7 +1447,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:schuko:output=3.6 kw",
+          "if": "socket:schuko:output=3.6 kw",
           "then": {
             "en": "<b>Schuko wall plug</b> without ground pin (CEE7/4 type F) outputs at most 3.6 kw A",
             "nl": "<b>Schuko stekker</b> zonder aardingspin (CEE7/4 type F) levert een vermogen van maximaal 3.6 kw A"
@@ -1482,7 +1482,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:typee:voltage=230 V",
+          "if": "socket:typee:voltage=230 V",
           "then": {
             "en": "<b>European wall plug</b> with ground pin (CEE7/4 type E) outputs 230 volt",
             "nl": "<b>Europese stekker</b> met aardingspin (CEE7/4 type E) heeft een spanning van 230 volt"
@@ -1517,7 +1517,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:typee:current=16 A",
+          "if": "socket:typee:current=16 A",
           "then": {
             "en": "<b>European wall plug</b> with ground pin (CEE7/4 type E) outputs at most 16 A",
             "nl": "<b>Europese stekker</b> met aardingspin (CEE7/4 type E) levert een stroom van maximaal 16 A"
@@ -1552,7 +1552,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:typee:output=3 kw",
+          "if": "socket:typee:output=3 kw",
           "then": {
             "en": "<b>European wall plug</b> with ground pin (CEE7/4 type E) outputs at most 3 kw A",
             "nl": "<b>Europese stekker</b> met aardingspin (CEE7/4 type E) levert een vermogen van maximaal 3 kw A"
@@ -1563,7 +1563,7 @@
           }
         },
         {
-          "if": "socket:socket:typee:output=22 kw",
+          "if": "socket:typee:output=22 kw",
           "then": {
             "en": "<b>European wall plug</b> with ground pin (CEE7/4 type E) outputs at most 22 kw A",
             "nl": "<b>Europese stekker</b> met aardingspin (CEE7/4 type E) levert een vermogen van maximaal 22 kw A"
@@ -1598,7 +1598,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:chademo:voltage=500 V",
+          "if": "socket:chademo:voltage=500 V",
           "then": {
             "en": "<b>Chademo</b> outputs 500 volt",
             "nl": "<b>Chademo</b> heeft een spanning van 500 volt"
@@ -1633,7 +1633,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:chademo:current=120 A",
+          "if": "socket:chademo:current=120 A",
           "then": {
             "en": "<b>Chademo</b> outputs at most 120 A",
             "nl": "<b>Chademo</b> levert een stroom van maximaal 120 A"
@@ -1668,7 +1668,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:chademo:output=50 kw",
+          "if": "socket:chademo:output=50 kw",
           "then": {
             "en": "<b>Chademo</b> outputs at most 50 kw A",
             "nl": "<b>Chademo</b> levert een vermogen van maximaal 50 kw A"
@@ -1703,7 +1703,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_cable:voltage=200 V",
+          "if": "socket:type1_cable:voltage=200 V",
           "then": {
             "en": "<b>Type 1 with cable</b> (J1772) outputs 200 volt",
             "nl": "<b>Type 1 met kabel</b> (J1772) heeft een spanning van 200 volt"
@@ -1714,7 +1714,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_cable:voltage=240 V",
+          "if": "socket:type1_cable:voltage=240 V",
           "then": {
             "en": "<b>Type 1 with cable</b> (J1772) outputs 240 volt",
             "nl": "<b>Type 1 met kabel</b> (J1772) heeft een spanning van 240 volt"
@@ -1749,7 +1749,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_cable:current=32 A",
+          "if": "socket:type1_cable:current=32 A",
           "then": {
             "en": "<b>Type 1 with cable</b> (J1772) outputs at most 32 A",
             "nl": "<b>Type 1 met kabel</b> (J1772) levert een stroom van maximaal 32 A"
@@ -1784,7 +1784,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_cable:output=3.7 kw",
+          "if": "socket:type1_cable:output=3.7 kw",
           "then": {
             "en": "<b>Type 1 with cable</b> (J1772) outputs at most 3.7 kw A",
             "nl": "<b>Type 1 met kabel</b> (J1772) levert een vermogen van maximaal 3.7 kw A"
@@ -1795,7 +1795,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_cable:output=7 kw",
+          "if": "socket:type1_cable:output=7 kw",
           "then": {
             "en": "<b>Type 1 with cable</b> (J1772) outputs at most 7 kw A",
             "nl": "<b>Type 1 met kabel</b> (J1772) levert een vermogen van maximaal 7 kw A"
@@ -1830,7 +1830,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1:voltage=200 V",
+          "if": "socket:type1:voltage=200 V",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs 200 volt",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) heeft een spanning van 200 volt"
@@ -1841,7 +1841,7 @@
           }
         },
         {
-          "if": "socket:socket:type1:voltage=240 V",
+          "if": "socket:type1:voltage=240 V",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs 240 volt",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) heeft een spanning van 240 volt"
@@ -1876,7 +1876,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1:current=32 A",
+          "if": "socket:type1:current=32 A",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs at most 32 A",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) levert een stroom van maximaal 32 A"
@@ -1911,7 +1911,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1:output=3.7 kw",
+          "if": "socket:type1:output=3.7 kw",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs at most 3.7 kw A",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) levert een vermogen van maximaal 3.7 kw A"
@@ -1922,7 +1922,7 @@
           }
         },
         {
-          "if": "socket:socket:type1:output=6.6 kw",
+          "if": "socket:type1:output=6.6 kw",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs at most 6.6 kw A",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) levert een vermogen van maximaal 6.6 kw A"
@@ -1933,7 +1933,7 @@
           }
         },
         {
-          "if": "socket:socket:type1:output=7 kw",
+          "if": "socket:type1:output=7 kw",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs at most 7 kw A",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) levert een vermogen van maximaal 7 kw A"
@@ -1944,7 +1944,7 @@
           }
         },
         {
-          "if": "socket:socket:type1:output=7.2 kw",
+          "if": "socket:type1:output=7.2 kw",
           "then": {
             "en": "<b>Type 1 <i>without</i> cable</b> (J1772) outputs at most 7.2 kw A",
             "nl": "<b>Type 1 <i>zonder</i> kabel</b> (J1772) levert een vermogen van maximaal 7.2 kw A"
@@ -1979,7 +1979,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_combo:voltage=400 V",
+          "if": "socket:type1_combo:voltage=400 V",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs 400 volt",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) heeft een spanning van 400 volt"
@@ -1990,7 +1990,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_combo:voltage=1000 V",
+          "if": "socket:type1_combo:voltage=1000 V",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs 1000 volt",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) heeft een spanning van 1000 volt"
@@ -2025,7 +2025,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_combo:current=50 A",
+          "if": "socket:type1_combo:current=50 A",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 50 A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een stroom van maximaal 50 A"
@@ -2036,7 +2036,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_combo:current=125 A",
+          "if": "socket:type1_combo:current=125 A",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 125 A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een stroom van maximaal 125 A"
@@ -2071,7 +2071,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type1_combo:output=50 kw",
+          "if": "socket:type1_combo:output=50 kw",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 50 kw A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een vermogen van maximaal 50 kw A"
@@ -2082,7 +2082,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_combo:output=62.5 kw",
+          "if": "socket:type1_combo:output=62.5 kw",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 62.5 kw A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een vermogen van maximaal 62.5 kw A"
@@ -2093,7 +2093,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_combo:output=150 kw",
+          "if": "socket:type1_combo:output=150 kw",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 150 kw A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een vermogen van maximaal 150 kw A"
@@ -2104,7 +2104,7 @@
           }
         },
         {
-          "if": "socket:socket:type1_combo:output=350 kw",
+          "if": "socket:type1_combo:output=350 kw",
           "then": {
             "en": "<b>Type 1 CCS</b> (aka Type 1 Combo) outputs at most 350 kw A",
             "nl": "<b>Type 1 CCS</b> (ook gekend als Type 1 Combo) levert een vermogen van maximaal 350 kw A"
@@ -2139,7 +2139,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger:voltage=480 V",
+          "if": "socket:tesla_supercharger:voltage=480 V",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs 480 volt",
             "nl": "<b>Tesla Supercharger</b> heeft een spanning van 480 volt"
@@ -2174,7 +2174,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger:current=125 A",
+          "if": "socket:tesla_supercharger:current=125 A",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs at most 125 A",
             "nl": "<b>Tesla Supercharger</b> levert een stroom van maximaal 125 A"
@@ -2185,7 +2185,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_supercharger:current=350 A",
+          "if": "socket:tesla_supercharger:current=350 A",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs at most 350 A",
             "nl": "<b>Tesla Supercharger</b> levert een stroom van maximaal 350 A"
@@ -2220,7 +2220,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger:output=120 kw",
+          "if": "socket:tesla_supercharger:output=120 kw",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs at most 120 kw A",
             "nl": "<b>Tesla Supercharger</b> levert een vermogen van maximaal 120 kw A"
@@ -2231,7 +2231,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_supercharger:output=150 kw",
+          "if": "socket:tesla_supercharger:output=150 kw",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs at most 150 kw A",
             "nl": "<b>Tesla Supercharger</b> levert een vermogen van maximaal 150 kw A"
@@ -2242,7 +2242,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_supercharger:output=250 kw",
+          "if": "socket:tesla_supercharger:output=250 kw",
           "then": {
             "en": "<b>Tesla Supercharger</b> outputs at most 250 kw A",
             "nl": "<b>Tesla Supercharger</b> levert een vermogen van maximaal 250 kw A"
@@ -2277,7 +2277,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2:voltage=230 V",
+          "if": "socket:type2:voltage=230 V",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs 230 volt",
             "nl": "<b>Type 2</b> (mennekes) heeft een spanning van 230 volt"
@@ -2288,7 +2288,7 @@
           }
         },
         {
-          "if": "socket:socket:type2:voltage=400 V",
+          "if": "socket:type2:voltage=400 V",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs 400 volt",
             "nl": "<b>Type 2</b> (mennekes) heeft een spanning van 400 volt"
@@ -2323,7 +2323,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2:current=16 A",
+          "if": "socket:type2:current=16 A",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs at most 16 A",
             "nl": "<b>Type 2</b> (mennekes) levert een stroom van maximaal 16 A"
@@ -2334,7 +2334,7 @@
           }
         },
         {
-          "if": "socket:socket:type2:current=32 A",
+          "if": "socket:type2:current=32 A",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs at most 32 A",
             "nl": "<b>Type 2</b> (mennekes) levert een stroom van maximaal 32 A"
@@ -2369,7 +2369,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2:output=11 kw",
+          "if": "socket:type2:output=11 kw",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs at most 11 kw A",
             "nl": "<b>Type 2</b> (mennekes) levert een vermogen van maximaal 11 kw A"
@@ -2380,7 +2380,7 @@
           }
         },
         {
-          "if": "socket:socket:type2:output=22 kw",
+          "if": "socket:type2:output=22 kw",
           "then": {
             "en": "<b>Type 2</b> (mennekes) outputs at most 22 kw A",
             "nl": "<b>Type 2</b> (mennekes) levert een vermogen van maximaal 22 kw A"
@@ -2415,7 +2415,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_combo:voltage=500 V",
+          "if": "socket:type2_combo:voltage=500 V",
           "then": {
             "en": "<b>Type 2 CCS</b> (mennekes) outputs 500 volt",
             "nl": "<b>Type 2 CCS</b> (mennekes) heeft een spanning van 500 volt"
@@ -2426,7 +2426,7 @@
           }
         },
         {
-          "if": "socket:socket:type2_combo:voltage=920 V",
+          "if": "socket:type2_combo:voltage=920 V",
           "then": {
             "en": "<b>Type 2 CCS</b> (mennekes) outputs 920 volt",
             "nl": "<b>Type 2 CCS</b> (mennekes) heeft een spanning van 920 volt"
@@ -2461,7 +2461,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_combo:current=125 A",
+          "if": "socket:type2_combo:current=125 A",
           "then": {
             "en": "<b>Type 2 CCS</b> (mennekes) outputs at most 125 A",
             "nl": "<b>Type 2 CCS</b> (mennekes) levert een stroom van maximaal 125 A"
@@ -2472,7 +2472,7 @@
           }
         },
         {
-          "if": "socket:socket:type2_combo:current=350 A",
+          "if": "socket:type2_combo:current=350 A",
           "then": {
             "en": "<b>Type 2 CCS</b> (mennekes) outputs at most 350 A",
             "nl": "<b>Type 2 CCS</b> (mennekes) levert een stroom van maximaal 350 A"
@@ -2507,7 +2507,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_combo:output=50 kw",
+          "if": "socket:type2_combo:output=50 kw",
           "then": {
             "en": "<b>Type 2 CCS</b> (mennekes) outputs at most 50 kw A",
             "nl": "<b>Type 2 CCS</b> (mennekes) levert een vermogen van maximaal 50 kw A"
@@ -2542,7 +2542,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_cable:voltage=230 V",
+          "if": "socket:type2_cable:voltage=230 V",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs 230 volt",
             "nl": "<b>Type 2 met kabel</b> (J1772) heeft een spanning van 230 volt"
@@ -2553,7 +2553,7 @@
           }
         },
         {
-          "if": "socket:socket:type2_cable:voltage=400 V",
+          "if": "socket:type2_cable:voltage=400 V",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs 400 volt",
             "nl": "<b>Type 2 met kabel</b> (J1772) heeft een spanning van 400 volt"
@@ -2588,7 +2588,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_cable:current=16 A",
+          "if": "socket:type2_cable:current=16 A",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs at most 16 A",
             "nl": "<b>Type 2 met kabel</b> (J1772) levert een stroom van maximaal 16 A"
@@ -2599,7 +2599,7 @@
           }
         },
         {
-          "if": "socket:socket:type2_cable:current=32 A",
+          "if": "socket:type2_cable:current=32 A",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs at most 32 A",
             "nl": "<b>Type 2 met kabel</b> (J1772) levert een stroom van maximaal 32 A"
@@ -2634,7 +2634,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:type2_cable:output=11 kw",
+          "if": "socket:type2_cable:output=11 kw",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs at most 11 kw A",
             "nl": "<b>Type 2 met kabel</b> (J1772) levert een vermogen van maximaal 11 kw A"
@@ -2645,7 +2645,7 @@
           }
         },
         {
-          "if": "socket:socket:type2_cable:output=22 kw",
+          "if": "socket:type2_cable:output=22 kw",
           "then": {
             "en": "<b>Type 2 with cable</b> (mennekes) outputs at most 22 kw A",
             "nl": "<b>Type 2 met kabel</b> (J1772) levert een vermogen van maximaal 22 kw A"
@@ -2680,7 +2680,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger_ccs:voltage=500 V",
+          "if": "socket:tesla_supercharger_ccs:voltage=500 V",
           "then": {
             "en": "<b>Tesla Supercharger CCS</b> (a branded type2_css) outputs 500 volt",
             "nl": "<b>Tesla Supercharger CCS</b> (een type2 CCS met Tesla-logo) heeft een spanning van 500 volt"
@@ -2691,7 +2691,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_supercharger_ccs:voltage=920 V",
+          "if": "socket:tesla_supercharger_ccs:voltage=920 V",
           "then": {
             "en": "<b>Tesla Supercharger CCS</b> (a branded type2_css) outputs 920 volt",
             "nl": "<b>Tesla Supercharger CCS</b> (een type2 CCS met Tesla-logo) heeft een spanning van 920 volt"
@@ -2726,7 +2726,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger_ccs:current=125 A",
+          "if": "socket:tesla_supercharger_ccs:current=125 A",
           "then": {
             "en": "<b>Tesla Supercharger CCS</b> (a branded type2_css) outputs at most 125 A",
             "nl": "<b>Tesla Supercharger CCS</b> (een type2 CCS met Tesla-logo) levert een stroom van maximaal 125 A"
@@ -2737,7 +2737,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_supercharger_ccs:current=350 A",
+          "if": "socket:tesla_supercharger_ccs:current=350 A",
           "then": {
             "en": "<b>Tesla Supercharger CCS</b> (a branded type2_css) outputs at most 350 A",
             "nl": "<b>Tesla Supercharger CCS</b> (een type2 CCS met Tesla-logo) levert een stroom van maximaal 350 A"
@@ -2772,7 +2772,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_supercharger_ccs:output=50 kw",
+          "if": "socket:tesla_supercharger_ccs:output=50 kw",
           "then": {
             "en": "<b>Tesla Supercharger CCS</b> (a branded type2_css) outputs at most 50 kw A",
             "nl": "<b>Tesla Supercharger CCS</b> (een type2 CCS met Tesla-logo) levert een vermogen van maximaal 50 kw A"
@@ -2807,7 +2807,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:voltage=480 V",
+          "if": "socket:tesla_destination:voltage=480 V",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs 480 volt",
             "nl": "<b>Tesla Supercharger (destination)</b> heeft een spanning van 480 volt"
@@ -2842,7 +2842,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:current=125 A",
+          "if": "socket:tesla_destination:current=125 A",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs at most 125 A",
             "nl": "<b>Tesla Supercharger (destination)</b> levert een stroom van maximaal 125 A"
@@ -2853,7 +2853,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:current=350 A",
+          "if": "socket:tesla_destination:current=350 A",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs at most 350 A",
             "nl": "<b>Tesla Supercharger (destination)</b> levert een stroom van maximaal 350 A"
@@ -2888,7 +2888,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:output=120 kw",
+          "if": "socket:tesla_destination:output=120 kw",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs at most 120 kw A",
             "nl": "<b>Tesla Supercharger (destination)</b> levert een vermogen van maximaal 120 kw A"
@@ -2899,7 +2899,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:output=150 kw",
+          "if": "socket:tesla_destination:output=150 kw",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs at most 150 kw A",
             "nl": "<b>Tesla Supercharger (destination)</b> levert een vermogen van maximaal 150 kw A"
@@ -2910,7 +2910,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:output=250 kw",
+          "if": "socket:tesla_destination:output=250 kw",
           "then": {
             "en": "<b>Tesla Supercharger (destination)</b> outputs at most 250 kw A",
             "nl": "<b>Tesla Supercharger (destination)</b> levert een vermogen van maximaal 250 kw A"
@@ -2945,7 +2945,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:voltage=230 V",
+          "if": "socket:tesla_destination:voltage=230 V",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs 230 volt",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) heeft een spanning van 230 volt"
@@ -2956,7 +2956,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:voltage=400 V",
+          "if": "socket:tesla_destination:voltage=400 V",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs 400 volt",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) heeft een spanning van 400 volt"
@@ -2991,7 +2991,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:current=16 A",
+          "if": "socket:tesla_destination:current=16 A",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs at most 16 A",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) levert een stroom van maximaal 16 A"
@@ -3002,7 +3002,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:current=32 A",
+          "if": "socket:tesla_destination:current=32 A",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs at most 32 A",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) levert een stroom van maximaal 32 A"
@@ -3037,7 +3037,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:tesla_destination:output=11 kw",
+          "if": "socket:tesla_destination:output=11 kw",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs at most 11 kw A",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) levert een vermogen van maximaal 11 kw A"
@@ -3048,7 +3048,7 @@
           }
         },
         {
-          "if": "socket:socket:tesla_destination:output=22 kw",
+          "if": "socket:tesla_destination:output=22 kw",
           "then": {
             "en": "<b>Tesla supercharger (destination)</b> (A Type 2 with cable branded as tesla) outputs at most 22 kw A",
             "nl": "<b>Tesla supercharger (destination</b> (Een Type 2 met kabel en Tesla-logo) levert een vermogen van maximaal 22 kw A"
@@ -3083,7 +3083,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:USB-A:voltage=5 V",
+          "if": "socket:USB-A:voltage=5 V",
           "then": {
             "en": "<b>USB</b> to charge phones and small electronics outputs 5 volt",
             "nl": "<b>USB</b> om GSMs en kleine electronica op te laden heeft een spanning van 5 volt"
@@ -3118,7 +3118,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:USB-A:current=1 A",
+          "if": "socket:USB-A:current=1 A",
           "then": {
             "en": "<b>USB</b> to charge phones and small electronics outputs at most 1 A",
             "nl": "<b>USB</b> om GSMs en kleine electronica op te laden levert een stroom van maximaal 1 A"
@@ -3129,7 +3129,7 @@
           }
         },
         {
-          "if": "socket:socket:USB-A:current=2 A",
+          "if": "socket:USB-A:current=2 A",
           "then": {
             "en": "<b>USB</b> to charge phones and small electronics outputs at most 2 A",
             "nl": "<b>USB</b> om GSMs en kleine electronica op te laden levert een stroom van maximaal 2 A"
@@ -3164,7 +3164,7 @@
       },
       "mappings": [
         {
-          "if": "socket:socket:USB-A:output=5w",
+          "if": "socket:USB-A:output=5w",
           "then": {
             "en": "<b>USB</b> to charge phones and small electronics outputs at most 5w A",
             "nl": "<b>USB</b> om GSMs en kleine electronica op te laden levert een vermogen van maximaal 5w A"
@@ -3175,7 +3175,7 @@
           }
         },
         {
-          "if": "socket:socket:USB-A:output=10w",
+          "if": "socket:USB-A:output=10w",
           "then": {
             "en": "<b>USB</b> to charge phones and small electronics outputs at most 10w A",
             "nl": "<b>USB</b> om GSMs en kleine electronica op te laden levert een vermogen van maximaal 10w A"


### PR DESCRIPTION
Use `socket:*` instead of `socket:socket:*`.
