### PR TITLE
Changeset tag `host`: Add domain and path

### DIFF
--- a/Logic/Osm/ChangesetHandler.ts
+++ b/Logic/Osm/ChangesetHandler.ts
@@ -347,13 +347,10 @@ export class ChangesetHandler {
         const self = this;
         return new Promise<number>(function (resolve, reject) {
 
-            let path = window.location.pathname;
-            path = path.substr(1, path.lastIndexOf("/"));
             const metadata = [
                 ["created_by", `MapComplete ${Constants.vNumber}`],
                 ["locale", Locale.language.data],
                 ["host", `${window.location.origin}${window.location.pathname}`],
-                ["path", path],
                 ["source", self.changes.state["currentUserLocation"]?.features?.data?.length > 0 ? "survey" : undefined],
                 ["imagery", self.changes.state["backgroundLayer"]?.data?.id],
                 ...changesetTags.map(cstag => [cstag.key, cstag.value])

--- a/Logic/Osm/ChangesetHandler.ts
+++ b/Logic/Osm/ChangesetHandler.ts
@@ -352,7 +352,7 @@ export class ChangesetHandler {
             const metadata = [
                 ["created_by", `MapComplete ${Constants.vNumber}`],
                 ["locale", Locale.language.data],
-                ["host", window.location.host],
+                ["host", `${window.location.origin}${window.location.pathname}`],
                 ["path", path],
                 ["source", self.changes.state["currentUserLocation"]?.features?.data?.length > 0 ? "survey" : undefined],
                 ["imagery", self.changes.state["backgroundLayer"]?.data?.id],


### PR DESCRIPTION
Extend the value of the changeset tag host key to include the full url of the editor. This way a reader of the changeset can open the editor based on this value. 

Example current changeset: https://www.openstreetmap.org/changeset/113127802
Example iD changeset with a clickable link that leads to the editor https://www.openstreetmap.org/changeset/117492192

---

Sitenote: I just did the same at https://github.com/zlant/parking-lanes/pull/90