### PR TITLE
Add VSCode settings to validate theme and layer JSONs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/assets/layers/*/*.json"
+            ],
+            "url": "./Docs/Schemas/LayerConfigJson.schema.json"
+        },
+        {
+            "fileMatch": [
+                "/assets/themes/*/*.json"
+            ],
+            "url": "./Docs/Schemas/LayoutConfigJson.schema.json"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,13 +2,15 @@
     "json.schemas": [
         {
             "fileMatch": [
-                "/assets/layers/*/*.json"
+                "/assets/layers/*/*.json",
+                "!/assets/layers/*/license_info.json"
             ],
             "url": "./Docs/Schemas/LayerConfigJson.schema.json"
         },
         {
             "fileMatch": [
-                "/assets/themes/*/*.json"
+                "/assets/themes/*/*.json",
+                "!/assets/themes/*/license_info.json"
             ],
             "url": "./Docs/Schemas/LayoutConfigJson.schema.json"
         }


### PR DESCRIPTION
The theme and layer JSON files are validated against the respective JSON Schema.
