### PR TITLE
Add `/.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/*
 node_modules
 .cache/*
 .idea/*
+.vscode/*
 scratch
 assets/editor-layer-index.json
 assets/generated/*


### PR DESCRIPTION
I am sad that https://github.com/pietervdvn/MapComplete/pull/721 was closed, but hope that this change is possible to make working with VS Code easier.  #ContributorExperienceMatters

---

- [x] The codebase is GPL-licensed. By opening a pull request, the new theme will be GPL too
