### PR TITLE
FYI Preview for themes

### DIFF
--- a/newThemeDevelopmentFolder/README.md
+++ b/newThemeDevelopmentFolder/README.md
@@ -1,0 +1,6 @@
+# New theme development folder
+
+1. Paste your theme in `my-theme.json``
+2. Open the folder locally
+3. Run `npx serve ./` from within the folder
+4. Open the page … which will show the index.html with your theme, using the base64 preview technique.

--- a/newThemeDevelopmentFolder/index.html
+++ b/newThemeDevelopmentFolder/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Learn more at https://tailwindcss.com/docs/installation/play-cdn -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <title>MapComplete Preview</title>
+</head>
+<body class="h-screen">
+  <div class="flex flex-col h-full w-full">
+    <div class="grid gab-5 grid-cols-2">
+      <input class="w-full bg-pink-50" value="" placeholder="Theme URl" id="theme-url" />
+      <input class="w-full bg-pink-50" value="" placeholder="MapComplete URl" id="mapcomplete-url" />
+    </div>
+    <div class="flex-grow border-t border-pink-400">
+      <iframe src="" class="col-span-2 w-full h-full"></iframe>
+    </div>
+  </div>
+  <script type="module">
+    import base64 from 'https://cdn.skypack.dev/base-64';
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+      async function encode() {
+        const themeFilename = 'my-theme.json'
+        const response = await fetch(themeFilename);
+        const json = await response.text();
+
+        // We cannot use this native btoa() approach, because that will break German characters form the JSON
+        //const encodedJson = btoa(unescape(encodeURIComponent(json)));
+        const encodedJson = base64.encode(json);
+
+        const url =  `https://mapcomplete.osm.be/theme?userlayout=true#${encodedJson}`
+        document.querySelector("iframe").src = url;
+        document.querySelector("#theme-url").value = `${window.location.href}${themeFilename}`;
+        document.querySelector("#mapcomplete-url").value = url;
+
+        console.log({json, encodedJson, url});
+      }
+      encode();
+    });
+  </script>
+</body>
+</html>

--- a/newThemeDevelopmentFolder/my-theme.json
+++ b/newThemeDevelopmentFolder/my-theme.json
@@ -1,0 +1,162 @@
+{
+  "id": "berlin_emergency_water_pumps",
+  "title": {
+    "de": "Berliner Pumpen"
+  },
+  "description": {
+    "de": "Die Karte zeigt die Funktionsfähigkeit und Position der Berliner Straßenbrunnen."
+  },
+  "maintainer": "MapComplete",
+  "icon": "./assets/themes/drinking_water/logo.svg",
+  "version": "0",
+  "startLat": 50.8465573,
+  "defaultBackgroundId": "CartoDB.Voyager",
+  "startLon": 4.351697,
+  "startZoom": 16,
+  "widenFactor": 2,
+  "layers": [
+    {
+      "id": "berlin_emergency_water_pump_layer",
+      "name": {
+        "de": "Berliner Straßenbrunnen"
+      },
+      "title": {
+        "render": {
+          "de": "Berliner Straßenbrunnen"
+        }
+      },
+      "source": {
+        "osmTags": {
+          "and": [
+            "man_made=water_well",
+            "network=Berliner Straßenbrunnen"
+          ]
+        }
+      },
+      "minzoom": 13,
+      "presets": [
+        {
+          "title": {
+            "de": "ein Berliner Straßenbrunnen"
+          },
+          "tags": [
+            "man_made=water_well"
+          ]
+        }
+      ],
+      "tagRenderings": [
+        "images",
+        {
+          "question": {
+            "de": "Ist dieser Straßenbrunnen funktionsfähig?"
+          },
+          "render": {
+            "de": "Status <i>{pump:status}</i>"
+          },
+          "freeform": {
+            "key": "pump:status"
+          },
+          "mappings": [
+            {
+              "if": "pump:status=ok",
+              "then": {
+                "de": "Dieser Straßenbrunnen funktioniert (20x pumpen produziert Wasser)"
+              }
+            },
+            {
+              "if": "pump:status=broken",
+              "then": {
+                "de": "Auch nach längerem Pumpen (20x-30x) fließt kein Wasser oder die Pumpe ist aus anderen, nicht weiter ausgeführten Gründen dauerhaft nicht funktionsfähig."
+              }
+            },
+            {
+              "if": "pump:status=missing_beam",
+              "then": {
+                "de": "Es fehlt der Handschwengel zum pumpen; die Pumpe kann daher nicht betätigt werden."
+              }
+            },
+            {
+              "if": "pump:status=out_of_order",
+              "then": {
+                "de": "Die Pumpe wurde (z.B. von einer Behörde bzw. der Senatsverwaltung) außer Betrieb gesetzt."
+              }
+            },
+            {
+              "if": "pump:status=locked",
+              "then": {
+                "de": "Die Pumpe ist z.B. mit einer Kette verschlossen."
+              }
+            },
+            {
+              "if": "pump:status=blocked",
+              "then": {
+                "de": "Der Zugang zur Pumpe ist blockiert (z.B. durch eine Baustelle)."
+              }
+            }
+          ]
+        },
+        {
+          "question": {
+            "de": "Wann wurde die Funktionsfähigkeit dieser Pumpe zuletzt überprüft?"
+          },
+          "render": {
+            "de": "Die Funktionsfähigkeit wurde zuletzt geprüft am {check_date}"
+          },
+          "freeform": {
+            "key": "check_date",
+            "type": "date"
+          },
+          "mappings": [
+            {
+              "if": "check_date:={_now:date}",
+              "then": "Surveyed today!"
+            }
+          ],
+          "id": "bench-check_date"
+        }
+      ],
+      "deletion": {
+        "softDeletionTags": {
+          "and": [
+            "razed:man_made:={man_made}",
+            "man_made="
+          ]
+        },
+        "neededChangesets": 1
+      },
+      "allowMove": {
+        "enableRelocation": false,
+        "enableImproveAccuraccy": true
+      },
+      "mapRendering": [
+        {
+          "icon": {
+            "render": "pin:#6BC4F7;./assets/layers/drinking_water/drips.svg"
+          },
+          "iconBadges": [
+            {
+              "if": {
+                "or": [
+                  "pump:status=broken",
+                  "pump:status=missing_beam",
+                  "pump:status=out_of_order",
+                  "pump:status=locked",
+                  "pump:status=blocked"
+                ]
+              },
+              "then": "close:#c33"
+            }
+          ],
+          "iconSize": "40,40,bottom",
+          "location": [
+            "point",
+            "centroid"
+          ]
+        }
+      ],
+      "description": {
+        "de": "Berliner Straßenbrunnen Layer"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
After https://github.com/pietervdvn/MapComplete/issues/787 failed, I looked for another convenient way to develop my theme.

This is my current status. Its an HTML file that has no code dependencies and can be served locally to preview the theme, using the public mapcomplete instance. 

It shows the served theme-json URL and the previewed mapcomplete+base64 URL in those two input fields at the top.

See readme for details.

Should this be helpful for https://github.com/pietervdvn/MapComplete/issues/707 and other users, feel free to integrate it in some way into the main codebase.

About this theme: I see it as a very local berlin-only theme and not as part of the main codebase. Will look for a place to host it later.

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/111561/165917950-6f395d48-f323-4105-a6ce-c6b713f15386.png">


--- 

- [x] The codebase is GPL-licensed. By opening a pull request, the new theme will be GPL too
- [ ] All images are included in the pull request and no images are loaded from an external service (e.g. Wikipedia)
- [ ] The [guidelines on how to make your own theme](https://github.com/pietervdvn/MapComplete/blob/master/Docs/Making_Your_Own_Theme.md)
  are read and followed
