### PR TITLE
Add alternative drinking water tag

### DIFF
--- a/assets/layers/drinking_water/drinking_water.json
+++ b/assets/layers/drinking_water/drinking_water.json
@@ -31,7 +31,13 @@
   "source": {
     "osmTags": {
       "and": [
-        "amenity=drinking_water",
+        {
+		    "or": [
+			    "amenity=drinking_water",
+			    "drinking_water=yes"
+		      ]
+		    }
+        "man_made!=reservoir_covered",
         "access!=permissive",
         "access!=private"
       ]


### PR DESCRIPTION
Add alternative tag for identifying the drinking water sources "drinking_water"="yes". The restriction on "man_made" prevents undercover reservoirs to be shown, which most probably do not allow to tap water from them.