### PR TITLE
Improve developer documentation for initial set up

### DIFF
--- a/Docs/Development_deployment.md
+++ b/Docs/Development_deployment.md
@@ -73,7 +73,8 @@ To use the WSL in Visual Studio Code:
    or `userlayout=true#<layout configuration>` as [Query parameter](URL_Parameters.md). Note that the shorter URLs (
    e.g. `bookcases.html`, `aed.html`, ...) _don't_ exist on the development version.
 
-### Dependencie
+Dependencies
+------------
 
 `make` , `python3` `g++`
 

--- a/Docs/Development_deployment.md
+++ b/Docs/Development_deployment.md
@@ -27,6 +27,7 @@ Devcontainer (see more details later).
 To develop and build MapComplete, you
 
 0. Make a fork and clone the repository. (We recommend a shallow clone with `git clone --filter=blob:none <repo>`)
+0. Install `python3`
 0. Install the nodejs version specified in [/.tool-versions](/.tool-versions)
     - On linux: install npm first `sudo apt install npm`, then install `n` using npm: ` npm install -g n`, which can
       then install node with `n install <node-version>`

--- a/Docs/Development_deployment.md
+++ b/Docs/Development_deployment.md
@@ -27,7 +27,7 @@ Devcontainer (see more details later).
 To develop and build MapComplete, you
 
 0. Make a fork and clone the repository. (We recommend a shallow clone with `git clone --filter=blob:none <repo>`)
-0. Install the nodejs version specified in [.tool-versions](./.tool-versions)
+0. Install the nodejs version specified in [/.tool-versions](/.tool-versions)
     - On linux: install npm first `sudo apt install npm`, then install `n` using npm: ` npm install -g n`, which can
       then install node with `n install <node-version>`
     - You can [use asdf to manage your runtime versions](https://asdf-vm.com/).

--- a/Docs/Development_deployment.md
+++ b/Docs/Development_deployment.md
@@ -78,7 +78,7 @@ Dependencies
 
 `make` , `python3` `g++`
 
-(run `nix-env -iA nixos.gnumake nixos.gdc nixos.python3`)
+(Nix users may run `nix-env -iA nixos.gnumake nixos.gdc nixos.python3`)
 
 Automatic deployment
 --------------------

--- a/Docs/Development_deployment.md
+++ b/Docs/Development_deployment.md
@@ -27,7 +27,9 @@ Devcontainer (see more details later).
 To develop and build MapComplete, you
 
 0. Make a fork and clone the repository. (We recommend a shallow clone with `git clone --filter=blob:none <repo>`)
-0. Install `python3`
+0. Install `python3` if you do not have it already
+    - On linux: `sudo apt install python3`
+    - On windows: find the latest download on the [Python Releases for Windows page](https://www.python.org/downloads/windows/)
 0. Install the nodejs version specified in [/.tool-versions](/.tool-versions)
     - On linux: install npm first `sudo apt install npm`, then install `n` using npm: ` npm install -g n`, which can
       then install node with `n install <node-version>`


### PR DESCRIPTION
Improve the docs for an initial run of the server locally.

- the path to tool-versions was wrong
- mention that python3 is needed
- clean up the markdown a bit

I don't mind squashing these commits