### PR TITLE
etymology: add "Weg" to postfixes that get removed

### DIFF
--- a/assets/layers/etymology/etymology.json
+++ b/assets/layers/etymology/etymology.json
@@ -185,6 +185,7 @@
                 "straße",
                 "platz",
                 "gasse",
+                "weg",
                 "grundschule",
                 "gymnasium",
                 "schule"


### PR DESCRIPTION
"Weg" (way) is a common suffix in street names in Germany.

See #1024.