### PR TITLE
Maproulette Icon showing on other layers

### DIFF
--- a/assets/layers/maproulette/maproulette.json
+++ b/assets/layers/maproulette/maproulette.json
@@ -3,7 +3,7 @@
   "source": {
     "geoJson": "https://maproulette.org/api/v2/tasks/box/{x_min}/{y_min}/{x_max}/{y_max}",
     "geoJsonZoomLevel": 16,
-    "osmTags": "id~*"
+    "osmTags": "title~*"
   },
   "mapRendering": [
     {

--- a/assets/layers/maproulette_challenge/maproulette_challenge.json
+++ b/assets/layers/maproulette_challenge/maproulette_challenge.json
@@ -6,7 +6,7 @@
     "de": "Ebene mit Aufgaben einer MapRoulette-Kampagne"
   },
   "source": {
-    "osmTags": "id~*",
+    "osmTags": "mr_taskId~*",
     "geoJson": "https://maproulette.org/api/v2/challenge/view/27971",
     "isOsmCache": false
   },


### PR DESCRIPTION
Should prevent the MapRoulette Icon from showing on other layers by using a different source