### PR TITLE
chore: correct license to a valid spdx identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "Editor"
   ],
   "author": "pietervdvn",
-  "license": "GPL",
+  "license": "GPL-3.0-or-later",
   "browserslist": [
     ">0.2%",
     "not dead",


### PR DESCRIPTION
not a big deal, but it's recommended that package.json use https://spdx.org/licenses/ as identifier for license...
so i've updated here