### PR TITLE
feat: improve cycle infra by excluding private/customer highways

### DIFF
--- a/assets/layers/cycleways_and_roads/cycleways_and_roads.json
+++ b/assets/layers/cycleways_and_roads/cycleways_and_roads.json
@@ -10,28 +10,38 @@
   "minzoom": 16,
   "source": {
     "osmTags": {
-      "or": [
-        "highway=cycleway",
-        "cycleway=lane",
-        "cycleway=shared_lane",
-        "cycleway=track",
-        "cyclestreet=yes",
-        "highway=residential",
-        "highway=tertiary",
-        "highway=unclassified",
-        "highway=primary",
-        "highway=secondary",
-        "highway=tertiary_link",
-        "highway=primary_link",
-        "highway=secondary_link",
-        "highway=service",
-        "highway=footway",
-        "highway=pedestrian",
-        "highway=living_street",
+      "and": [
         {
-          "and": [
-            "highway=path",
-            "bicycle=designated"
+          "or": [
+            "highway=cycleway",
+            "cycleway=lane",
+            "cycleway=shared_lane",
+            "cycleway=track",
+            "cyclestreet=yes",
+            "highway=residential",
+            "highway=tertiary",
+            "highway=unclassified",
+            "highway=primary",
+            "highway=secondary",
+            "highway=tertiary_link",
+            "highway=primary_link",
+            "highway=secondary_link",
+            "highway=service",
+            "highway=footway",
+            "highway=pedestrian",
+            "highway=living_street",
+            {
+              "and": [
+                "highway=path",
+                "bicycle=designated"
+              ]
+            }
+          ]
+        },
+        {
+          "or": [
+            "access!~private",
+            "access!~no"
           ]
         }
       ]
@@ -1593,6 +1603,10 @@
           {
             "if": "highway=cycleway",
             "then": "rgba(0, 189, 141, 0.7)"
+          },
+          {
+            "if": "highway=separate",
+            "then": "rgba(0, 245, 86, 0.33)"
           },
           {
             "if": "highway=path",


### PR DESCRIPTION
hey, 

here is an attempt,

i my area there are a lot of service alleys & other stuff that put a lot of clutter to the map, 
so the intent is to exclude them as they are not really important here.

in addition, i'll color the separate cycleways just to have an idea that the cycleway is well defined 