### PR TITLE
Typo fix: cyclstreet to cyclestreet

### DIFF
--- a/Docs/Layers/all_streets.md
+++ b/Docs/Layers/all_streets.md
@@ -90,7 +90,7 @@ The question is  Is the street <b>{name}</b> a cyclestreet?
 
   - This street is a cyclestreet (and has a speed limit of 30 km/h)  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:maxspeed' target='_blank'>maxspeed</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:maxspeed%3D30' target='_blank'>30</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:overtaking:motor_vehicle' target='_blank'>overtaking:motor_vehicle</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:overtaking:motor_vehicle%3Dno' target='_blank'>no</a>`
   - This street is a cyclestreet  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>`
-  - This street will become a cyclstreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
+  - This street will become a cyclestreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
   - This street is not a cyclestreet  corresponds with  ``
 
 

--- a/Docs/Layers/fietsstraat.md
+++ b/Docs/Layers/fietsstraat.md
@@ -89,7 +89,7 @@ The question is  Is the street <b>{name}</b> a cyclestreet?
 
   - This street is a cyclestreet (and has a speed limit of 30 km/h)  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:maxspeed' target='_blank'>maxspeed</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:maxspeed%3D30' target='_blank'>30</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:overtaking:motor_vehicle' target='_blank'>overtaking:motor_vehicle</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:overtaking:motor_vehicle%3Dno' target='_blank'>no</a>`
   - This street is a cyclestreet  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>`
-  - This street will become a cyclstreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
+  - This street will become a cyclestreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
   - This street is not a cyclestreet  corresponds with  ``
 
 

--- a/Docs/Layers/toekomstige_fietsstraat.md
+++ b/Docs/Layers/toekomstige_fietsstraat.md
@@ -89,7 +89,7 @@ The question is  Is the street <b>{name}</b> a cyclestreet?
 
   - This street is a cyclestreet (and has a speed limit of 30 km/h)  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:maxspeed' target='_blank'>maxspeed</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:maxspeed%3D30' target='_blank'>30</a>&<a href='https://wiki.openstreetmap.org/wiki/Key:overtaking:motor_vehicle' target='_blank'>overtaking:motor_vehicle</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:overtaking:motor_vehicle%3Dno' target='_blank'>no</a>`
   - This street is a cyclestreet  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:cyclestreet' target='_blank'>cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:cyclestreet%3Dyes' target='_blank'>yes</a>`
-  - This street will become a cyclstreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
+  - This street will become a cyclestreet soon  corresponds with  `<a href='https://wiki.openstreetmap.org/wiki/Key:proposed:cyclestreet' target='_blank'>proposed:cyclestreet</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:proposed:cyclestreet%3Dyes' target='_blank'>yes</a>`
   - This street is not a cyclestreet  corresponds with  ``
 
 

--- a/Docs/TagInfo/mapcomplete_cyclestreets.json
+++ b/Docs/TagInfo/mapcomplete_cyclestreets.json
@@ -63,12 +63,12 @@
     },
     {
       "key": "cyclestreet",
-      "description": "Layer 'Cyclestreets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
+      "description": "Layer 'Cyclestreets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
       "value": ""
     },
     {
       "key": "proposed:cyclestreet",
-      "description": "Layer 'Cyclestreets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
+      "description": "Layer 'Cyclestreets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
       "value": "yes"
     },
     {
@@ -143,12 +143,12 @@
     },
     {
       "key": "cyclestreet",
-      "description": "Layer 'Future cyclestreet' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
+      "description": "Layer 'Future cyclestreet' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
       "value": ""
     },
     {
       "key": "proposed:cyclestreet",
-      "description": "Layer 'Future cyclestreet' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
+      "description": "Layer 'Future cyclestreet' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
       "value": "yes"
     },
     {
@@ -233,12 +233,12 @@
     },
     {
       "key": "cyclestreet",
-      "description": "Layer 'All streets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
+      "description": "Layer 'All streets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets') Picking this answer will delete the key cyclestreet.",
       "value": ""
     },
     {
       "key": "proposed:cyclestreet",
-      "description": "Layer 'All streets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclstreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
+      "description": "Layer 'All streets' shows proposed:cyclestreet=yes with a fixed text, namely 'This street will become a cyclestreet soon' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Cyclestreets')",
       "value": "yes"
     },
     {

--- a/assets/themes/cyclestreets/cyclestreets.json
+++ b/assets/themes/cyclestreets/cyclestreets.json
@@ -453,8 +453,8 @@
             },
             "then": {
               "nl": "Deze straat wordt binnenkort een fietsstraat",
-              "en": "This street will become a cyclstreet soon",
-              "ja": "この通りはまもなくcyclstreetになるだろう",
+              "en": "This street will become a cyclestreet soon",
+              "ja": "この通りはまもなくcyclestreetになるだろう",
               "nb_NO": "Denne gaten vil bli sykkelvei ganske snart",
               "de": "Diese Straße wird bald eine Fahrradstraße sein",
               "it": "Diverrà tra poco una strada ciclabile",

--- a/langs/themes/en.json
+++ b/langs/themes/en.json
@@ -474,7 +474,7 @@
                             "then": "This street is a cyclestreet"
                         },
                         "4": {
-                            "then": "This street will become a cyclstreet soon"
+                            "then": "This street will become a cyclestreet soon"
                         },
                         "5": {
                             "then": "This street will become a bicycle road soon"

--- a/langs/themes/ja.json
+++ b/langs/themes/ja.json
@@ -295,7 +295,7 @@
                             "then": "この通りはcyclestreetだ"
                         },
                         "4": {
-                            "then": "この通りはまもなくcyclstreetになるだろう"
+                            "then": "この通りはまもなくcyclestreetになるだろう"
                         },
                         "6": {
                             "then": "この通りはcyclestreetではない"


### PR DESCRIPTION
I bluntly `grep`ed for all instances of cyclstreet and renamed those to cyclestreet.
I guess some files might be automatically generated, so I might have
overdone it :)