### PR TITLE
More tweaks to OnWheels parking

### DIFF
--- a/assets/layers/parking_spaces/parking_spaces.json
+++ b/assets/layers/parking_spaces/parking_spaces.json
@@ -171,7 +171,16 @@
       "en": "Parking Space",
       "de": "Stellplatz",
       "nl": "Parkeerplek"
-    }
+    },
+    "mappings": [
+      {
+        "if": "parking_space=disabled",
+        "then": {
+          "en": "Disabled Parking Space",
+          "nl": "Parkeerplek voor gehandicapten"
+        }
+      }
+    ]
   },
   "mapRendering": [
     {

--- a/assets/themes/onwheels/onwheels.json
+++ b/assets/themes/onwheels/onwheels.json
@@ -199,9 +199,19 @@
           {
             "icon": {
               "mappings": null
-            }
+            },
+            "iconSize": "30,30,center",
+            "iconBadges": [
+              {
+                "if": "parking_space=disabled",
+                "then": "./assets/layers/toilet/wheelchair.svg"
+              }
+            ]
           }
-        ]
+        ],
+        "name": {
+          "en": "Disabled parking spaces"
+        }
       },
       "hideTagRenderingsWithLabels": [
         "type",

--- a/assets/themes/onwheels/onwheels.json
+++ b/assets/themes/onwheels/onwheels.json
@@ -181,7 +181,20 @@
         "mapRendering": [
           {
             "icon": "./assets/themes/onwheels/parking.svg",
-            "iconSize": "40,40,bottom"
+            "iconSize": {
+              "render": "20,20,bottom",
+              "mappings": [
+                {
+                  "if": {
+                    "or": [
+                      "capacity:disabled>0",
+                      "capacity:disabled=yes"
+                    ]
+                  },
+                  "then": "40,40,bottom"
+                }
+              ]
+            }
           },
           {
             "color": "#225f92"


### PR DESCRIPTION
Enlarges icon for parking space, adds iconbadge to highlight the fact that it is a disabled space, now looks like this: ![new parking space rendering](https://user-images.githubusercontent.com/1395345/209569726-714876b7-7f08-47ec-be42-9fe42f40474f.png) 

Also changes the parking icons to be smaller for parking lots without disabled parking, to emphasize the parking lots that have disabled parking.

Before:
![Before](https://user-images.githubusercontent.com/1395345/209569860-23ee7d6e-5b51-4fd6-9129-8ebd03ec9c35.png)

After:
![After](https://user-images.githubusercontent.com/1395345/209569861-69becea3-1367-4fc7-9f5a-f73c32cd78ff.png)

