### PR TITLE
Update cycleways_and_roads.json

### DIFF
--- a/assets/layers/cycleways_and_roads/cycleways_and_roads.json
+++ b/assets/layers/cycleways_and_roads/cycleways_and_roads.json
@@ -1199,7 +1199,7 @@
             "bicycle=designated",
             "mofa=designated",
             "moped=no",
-            "speed_pedelec=no",
+            "speed_pedelec=yes",
             "segregated=yes"
           ],
           "icon": {


### PR DESCRIPTION
Updated following the update of the "wegcode" in october 2022. Speed pedelecs now allowed to make use of D9 signed cyclepaths (and forced to use them when the maximum allowed speed > 50 km/h)

