### PR TITLE
Query typo fix.

### DIFF
--- a/assets/layers/shops/shops.json
+++ b/assets/layers/shops/shops.json
@@ -140,7 +140,7 @@
       "condition": {
         "or": [
           "shop~.*copyshop.*",
-          "shop~.*stationary.*",
+          "shop~.*stationery.*",
           "service:print=yes"
         ]
       },


### PR DESCRIPTION
 This would be a stationery shop, with an "e", not an "a."