### PR TITLE
Updated rainbow crossing theme to use surface:colour on footways inst…

### DIFF
--- a/Docs/Layers/rainbow_crossing_high_zoom.md
+++ b/Docs/Layers/rainbow_crossing_high_zoom.md
@@ -41,10 +41,10 @@ Elements must have the all of following tags to be shown on this layer:
 
 
   - <a href='https://wiki.openstreetmap.org/wiki/Key:highway' target='_blank'>highway</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcrossing' target='_blank'>crossing</a>
-  - <a href='https://wiki.openstreetmap.org/wiki/Key:crossing:marking' target='_blank'>crossing:marking</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:crossing:marking%3Drainbow' target='_blank'>rainbow</a>
+  - <a href='https://wiki.openstreetmap.org/wiki/Key:surface:colour' target='_blank'>surface:colour</a>=<a href='https://wiki.openstreetmap.org/wiki/Tag:surface:colour%3Drainbow' target='_blank'>rainbow</a>
 
 
-[Execute on overpass](http://overpass-turbo.eu/?Q=%5Bout%3Ajson%5D%5Btimeout%3A90%5D%3B(%20%20%20%20nwr%5B%22crossing%3Amarking%22%3D%22rainbow%22%5D%5B%22highway%22%3D%22crossing%22%5D(%7B%7Bbbox%7D%7D)%3B%0A)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B)
+[Execute on overpass](http://overpass-turbo.eu/?Q=%5Bout%3Ajson%5D%5Btimeout%3A90%5D%3B(%20%20%20%20nwr%5B%22surface%3Acolour%22%3D%22rainbow%22%5D%5B%22highway%22%3D%22crossing%22%5D(%7B%7Bbbox%7D%7D)%3B%0A)%3Bout%20body%3B%3E%3Bout%20skel%20qt%3B)
 
 
 
@@ -77,9 +77,9 @@ The question is  *Does this crossing has rainbow paintings?*
 
 
 
-  - *This crossing has rainbow paintings*  corresponds with  `crossing:marking=rainbow`
-  - *No rainbow paintings here*  corresponds with  `not:crossing:marking=rainbow`
-  - *No rainbow paintings here*  corresponds with  `crossing:marking!=rainbow`
+  - *This crossing has rainbow paintings*  corresponds with  `surface:colour=rainbow`
+  - *No rainbow paintings here*  corresponds with  `not:surface:colour=rainbow`
+  - *No rainbow paintings here*  corresponds with  `surface:colour!=rainbow`
   - This option cannot be chosen as answer
 
 

--- a/Docs/Layers/rainbow_crossings.md
+++ b/Docs/Layers/rainbow_crossings.md
@@ -77,9 +77,9 @@ The question is  *Does this crossing has rainbow paintings?*
 
 
 
-  - *This crossing has rainbow paintings*  corresponds with  `crossing:marking=rainbow`
-  - *No rainbow paintings here*  corresponds with  `not:crossing:marking=rainbow`
-  - *No rainbow paintings here*  corresponds with  `crossing:marking!=rainbow`
+  - *This crossing has rainbow paintings*  corresponds with  `surface:colour=rainbow`
+  - *No rainbow paintings here*  corresponds with  `not:surface:colour=rainbow`
+  - *No rainbow paintings here*  corresponds with  `surface:colour!=rainbow`
   - This option cannot be chosen as answer
 
 

--- a/Docs/TagInfo/mapcomplete_rainbow_crossings.json
+++ b/Docs/TagInfo/mapcomplete_rainbow_crossings.json
@@ -11,7 +11,7 @@
   },
   "tags": [
     {
-      "key": "highway",
+      "key": "footway",
       "description": "The MapComplete theme Rainbow pedestrian crossings has a layer Crossings with rainbow paintings showing features with this tag",
       "value": "crossing"
     },
@@ -32,13 +32,13 @@
       "description": "The layer 'Crossings with rainbow paintings allows to upload images and adds them under the 'image'-tag (and image:0, image:1, ... for multiple images). Furhtermore, this layer shows images based on the keys image, wikidata, wikipedia, wikimedia_commons and mapillary"
     },
     {
-      "key": "crossing:marking",
-      "description": "Layer 'Crossings with rainbow paintings' shows crossing:marking=rainbow with a fixed text, namely 'This crossing has rainbow paintings' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Rainbow pedestrian crossings') (This is only shown if highway=crossing)",
+      "key": "surface:colour",
+      "description": "Layer 'Crossings with rainbow paintings' shows surface:colour=rainbow with a fixed text, namely 'This crossing has rainbow paintings' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Rainbow pedestrian crossings') (This is only shown if footway=crossing)",
       "value": "rainbow"
     },
     {
-      "key": "not:crossing:marking",
-      "description": "Layer 'Crossings with rainbow paintings' shows not:crossing:marking=rainbow with a fixed text, namely 'No rainbow paintings here' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Rainbow pedestrian crossings') (This is only shown if highway=crossing)",
+      "key": "not:surface:colour",
+      "description": "Layer 'Crossings with rainbow paintings' shows not:surface:colour=rainbow with a fixed text, namely 'No rainbow paintings here' and allows to pick this as a default answer (in the MapComplete.osm.be theme 'Rainbow pedestrian crossings') (This is only shown if footway=crossing)",
       "value": "rainbow"
     }
   ]

--- a/assets/layers/rainbow_crossings/rainbow_crossings.json
+++ b/assets/layers/rainbow_crossings/rainbow_crossings.json
@@ -13,7 +13,12 @@
     "ca": "Una capa que mostra els passos de vianants pintats amb de l'arc de Sant Martí"
   },
   "source": {
-    "osmTags": "highway=crossing"
+    "osmTags": {
+      "and": [
+        "highway=footway",
+        "footway=crossing"
+      ]
+    }
   },
   "minzoom": 17,
   "title": {
@@ -34,7 +39,7 @@
         "fr": "un passage"
       },
       "tags": [
-        "highway=crossing"
+        "footway=crossing"
       ],
       "description": {
         "en": "Pedestrian crossing",
@@ -62,10 +67,10 @@
         "fr": "Ce passage a-t-il une peinture arc-en-ciel ?",
         "ca": "Aquest pas de vianants està pintat amb l'arc de Sant Martí?"
       },
-      "condition": "highway=crossing",
+      "condition": "footway=crossing",
       "mappings": [
         {
-          "if": "crossing:marking=rainbow",
+          "if": "surface:colour=rainbow",
           "then": {
             "en": "This crossing has rainbow paintings",
             "de": "Der Überweg hat eine Markierung in Regenbogenfarben",
@@ -78,7 +83,7 @@
           }
         },
         {
-          "if": "not:crossing:marking=rainbow",
+          "if": "not:surface:colour=rainbow",
           "then": {
             "en": "No rainbow paintings here",
             "de": "Hier gibt es kein Markierung in Regenbogenfarben",
@@ -88,7 +93,7 @@
           "icon": "./assets/themes/rainbow_crossings/crossing.svg"
         },
         {
-          "if": "crossing:marking!=rainbow",
+          "if": "surface:colour!=rainbow",
           "then": {
             "en": "No rainbow paintings here",
             "de": "Hier gibt es kein Markierung in Regenbogenfarben",
@@ -107,7 +112,7 @@
         "render": "./assets/themes/rainbow_crossings/crossing.svg",
         "mappings": [
           {
-            "if": "crossing:marking=rainbow",
+            "if": "surface:colour=rainbow",
             "then": "./assets/themes/rainbow_crossings/logo.svg"
           }
         ]

--- a/assets/themes/rainbow_crossings/rainbow_crossings.json
+++ b/assets/themes/rainbow_crossings/rainbow_crossings.json
@@ -38,7 +38,7 @@
         "source": {
           "osmTags": {
             "and+": [
-              "crossing:marking=rainbow"
+              "surface:colour=rainbow"
             ]
           }
         }


### PR DESCRIPTION
…ead of crossing:marking (deprecated)


This pull request is an update of the existing theme.
This is because the tag used until now (crossing:marking=rainbow) has been discussed within the community in the last months and is now considered deprecated (see wiki).

The new recommended tagging scheme is "surface:colour=rainbow".  This is to be used on footways with highway=footway + footway=crossing.  This is part of a more general tagging scheme that can also deal with other painting styles (beyond the scope of this theme).


- [x] The codebase is GPL-licensed. By opening a pull request, the new theme will be GPL too
- [x] All images are included in the pull request and no images are loaded from an external service (e.g. Wikipedia)
- [x] The [guidelines on how to make your own theme](https://github.com/pietervdvn/MapComplete/blob/master/Docs/Making_Your_Own_Theme.md)
  are read and followed
