### PR TITLE
Prettier: Fix new line setting

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,6 +3,6 @@
   "printWidth": 100,
   "plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
   "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
-  "svelteBracketNewLine": false,
+  "bracketSameLine": false,
   "htmlWhitespaceSensitivity": "ignore"
 }


### PR DESCRIPTION
Thanks for merging https://github.com/pietervdvn/MapComplete/pull/1459 and https://github.com/pietervdvn/MapComplete/pull/1460.

Unfortunately I am still having issues locally.

a. when I run `npm run format` I am still getting a lot of files and while working on https://github.com/pietervdvn/MapComplete/pull/1463 there where a few files, especially `UI/Popup/AddNewPoint/AddNewPoint.svelte` which reformatted dramatically on safe. I disabled the auto-formatting for those files for that PR.

b. when my VS Code runs the formatter "on safe" id behaves differently from what "npm run format" does
I am not sure why, yet.
- Some changes are tue to (a)
- However, "on save" has a different opinion on where the closing bracket should go.
  This PR fixes this, by updating the config.

---

https://github.com/sveltejs/prettier-plugin-svelte#svelte-bracket-new-line states
> Deprecated since 2.5.0. Use Prettier 2.4.0 and bracketSameLine instead.

The new setting bracketSameLine=false is in line with how the pages are formatted mostly ATM, so it causes the least amount of change on save.

---

@pietervdvn after merge, could you run `npm run format` again; it should result in quite a few additional changes. Including some of the files from https://github.com/pietervdvn/MapComplete/pull/1463  which will only then be auto-formatted.