### PR TITLE
adding copyright and license SPDX comment headers for several files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 MapComplete <https://mapcomplete.osm.be/>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 dist/*
 node_modules
 .cache/*

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/GPL-3.0-only.txt
+++ b/LICENSES/GPL-3.0-only.txt
@@ -1,0 +1,232 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions.
+
+“This License” refers to version 3 of the GNU General Public License.
+
+“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations.
+
+To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work.
+
+A “covered work” means either the unmodified Program or a work based on the Program.
+
+To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work.
+
+A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+     a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+     b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”.
+
+     c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+     d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+     a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+     b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+     c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+     d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+     e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+     a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+     b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+     c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+     d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+     e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+     f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+
+An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's “contributor version”.
+
+A contributor's “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Use with the GNU Affero General Public License.
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+
+14. Revised Versions of this License.
+The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+     <program>  Copyright (C) <year>  <name of author>
+     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+     This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an “about box”.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/Logic/Actors/BackgroundLayerResetter.ts
+++ b/Logic/Actors/BackgroundLayerResetter.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../UIEventSource"
 import { Utils } from "../../Utils"
 import { RasterLayerPolygon, RasterLayerUtils } from "../../Models/RasterLayers"

--- a/Logic/Actors/ChangeToElementsActor.ts
+++ b/Logic/Actors/ChangeToElementsActor.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Changes } from "../Osm/Changes"
 import FeaturePropertiesStore from "../FeatureSource/Actors/FeaturePropertiesStore"
 

--- a/Logic/Actors/GeoLocationHandler.ts
+++ b/Logic/Actors/GeoLocationHandler.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { QueryParameters } from "../Web/QueryParameters"
 import { BBox } from "../BBox"
 import Constants from "../../Models/Constants"

--- a/Logic/Actors/InitialMapPositioning.ts
+++ b/Logic/Actors/InitialMapPositioning.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import LayoutConfig from "../../Models/ThemeConfig/LayoutConfig"
 import { LocalStorageSource } from "../Web/LocalStorageSource"

--- a/Logic/Actors/NoElementsInViewDetector.ts
+++ b/Logic/Actors/NoElementsInViewDetector.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { BBox } from "../BBox"
 import { Store } from "../UIEventSource"
 import ThemeViewState from "../../Models/ThemeViewState"

--- a/Logic/Actors/PendingChangesUploader.ts
+++ b/Logic/Actors/PendingChangesUploader.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Changes } from "../Osm/Changes"
 import Constants from "../../Models/Constants"
 import { UIEventSource } from "../UIEventSource"

--- a/Logic/Actors/Readme.md
+++ b/Logic/Actors/Readme.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+
+SPDX-License-Identifier: GPL-3.0-ONLY
+-->
+
 Actors
 ======
 

--- a/Logic/Actors/SelectedElementTagsUpdater.ts
+++ b/Logic/Actors/SelectedElementTagsUpdater.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * This actor will download the latest version of the selected element from OSM and update the tags if necessary.
  */

--- a/Logic/Actors/TitleHandler.ts
+++ b/Logic/Actors/TitleHandler.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../UIEventSource"
 import Locale from "../../UI/i18n/Locale"
 import Combine from "../../UI/Base/Combine"

--- a/Logic/BBox.ts
+++ b/Logic/BBox.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as turf from "@turf/turf"
 import { TileRange, Tiles } from "../Models/TileRange"
 import { GeoOperations } from "./GeoOperations"

--- a/Logic/ContributorCount.ts
+++ b/Logic/ContributorCount.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /// Given a feature source, calculates a list of OSM-contributors who mapped the latest versions
 import { Store, UIEventSource } from "./UIEventSource"
 import { BBox } from "./BBox"

--- a/Logic/DetermineLayout.ts
+++ b/Logic/DetermineLayout.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import LayoutConfig from "../Models/ThemeConfig/LayoutConfig"
 import { QueryParameters } from "./Web/QueryParameters"
 import { AllKnownLayouts } from "../Customizations/AllKnownLayouts"

--- a/Logic/ExtraFunctions.ts
+++ b/Logic/ExtraFunctions.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { GeoOperations } from "./GeoOperations"
 import Combine from "../UI/Base/Combine"
 import BaseUIElement from "../UI/BaseUIElement"

--- a/Logic/FeatureSource/Actors/FeaturePropertiesStore.ts
+++ b/Logic/FeatureSource/Actors/FeaturePropertiesStore.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "../FeatureSource"
 import { UIEventSource } from "../../UIEventSource"
 

--- a/Logic/FeatureSource/Actors/GeoIndexedStore.ts
+++ b/Logic/FeatureSource/Actors/GeoIndexedStore.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource, FeatureSourceForLayer } from "../FeatureSource"
 import { Feature } from "geojson"
 import { BBox } from "../../BBox"

--- a/Logic/FeatureSource/Actors/SaveFeatureSourceToLocalStorage.ts
+++ b/Logic/FeatureSource/Actors/SaveFeatureSourceToLocalStorage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "../FeatureSource"
 import { Feature } from "geojson"
 import TileLocalStorage from "./TileLocalStorage"

--- a/Logic/FeatureSource/Actors/TileLocalStorage.ts
+++ b/Logic/FeatureSource/Actors/TileLocalStorage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { IdbLocalStorage } from "../../Web/IdbLocalStorage"
 import { UIEventSource } from "../../UIEventSource"
 

--- a/Logic/FeatureSource/FeatureSource.ts
+++ b/Logic/FeatureSource/FeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../UIEventSource"
 import FilteredLayer from "../../Models/FilteredLayer"
 import { Feature } from "geojson"

--- a/Logic/FeatureSource/PerLayerFeatureSourceSplitter.ts
+++ b/Logic/FeatureSource/PerLayerFeatureSourceSplitter.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "./FeatureSource"
 import FilteredLayer from "../../Models/FilteredLayer"
 import SimpleFeatureSource from "./Sources/SimpleFeatureSource"

--- a/Logic/FeatureSource/Sources/ChangeGeometryApplicator.ts
+++ b/Logic/FeatureSource/Sources/ChangeGeometryApplicator.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Applies geometry changes from 'Changes' onto every feature of a featureSource
  */

--- a/Logic/FeatureSource/Sources/ClippedFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/ClippedFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "../FeatureSource"
 import { Feature, Polygon } from "geojson"
 import StaticFeatureSource from "./StaticFeatureSource"

--- a/Logic/FeatureSource/Sources/FeatureSourceMerger.ts
+++ b/Logic/FeatureSource/Sources/FeatureSourceMerger.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../../UIEventSource"
 import { FeatureSource, IndexedFeatureSource } from "../FeatureSource"
 import { Feature } from "geojson"

--- a/Logic/FeatureSource/Sources/FilteringFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/FilteringFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../../UIEventSource"
 import FilteredLayer from "../../../Models/FilteredLayer"
 import { FeatureSource } from "../FeatureSource"

--- a/Logic/FeatureSource/Sources/GeoJsonSource.ts
+++ b/Logic/FeatureSource/Sources/GeoJsonSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Fetches a geojson file somewhere and passes it along
  */

--- a/Logic/FeatureSource/Sources/LastClickFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/LastClickFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import LayoutConfig from "../../../Models/ThemeConfig/LayoutConfig"
 import { WritableFeatureSource } from "../FeatureSource"
 import { ImmutableStore, Store, UIEventSource } from "../../UIEventSource"

--- a/Logic/FeatureSource/Sources/LayoutSource.ts
+++ b/Logic/FeatureSource/Sources/LayoutSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import GeoJsonSource from "./GeoJsonSource"
 import LayerConfig from "../../../Models/ThemeConfig/LayerConfig"
 import { FeatureSource } from "../FeatureSource"

--- a/Logic/FeatureSource/Sources/NewGeometryFromChangesFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/NewGeometryFromChangesFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Changes } from "../../Osm/Changes"
 import { OsmNode, OsmRelation, OsmWay } from "../../Osm/OsmObject"
 import { IndexedFeatureSource, WritableFeatureSource } from "../FeatureSource"

--- a/Logic/FeatureSource/Sources/OsmFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/OsmFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../../Utils"
 import OsmToGeoJson from "osmtogeojson"
 import { ImmutableStore, Store, UIEventSource } from "../../UIEventSource"

--- a/Logic/FeatureSource/Sources/OverpassFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/OverpassFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Feature } from "geojson"
 import { FeatureSource } from "../FeatureSource"
 import { ImmutableStore, Store, UIEventSource } from "../../UIEventSource"

--- a/Logic/FeatureSource/Sources/SimpleFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/SimpleFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../../UIEventSource"
 import FilteredLayer from "../../../Models/FilteredLayer"
 import { FeatureSourceForLayer } from "../FeatureSource"

--- a/Logic/FeatureSource/Sources/SnappingFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/SnappingFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "../FeatureSource"
 import { Store, UIEventSource } from "../../UIEventSource"
 import { Feature, Point } from "geojson"

--- a/Logic/FeatureSource/Sources/StaticFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/StaticFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource } from "../FeatureSource"
 import { ImmutableStore, Store } from "../../UIEventSource"
 import { Feature } from "geojson"

--- a/Logic/FeatureSource/Sources/TouchesBboxFeatureSource.ts
+++ b/Logic/FeatureSource/Sources/TouchesBboxFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { FeatureSource, FeatureSourceForLayer } from "../FeatureSource"
 import StaticFeatureSource from "./StaticFeatureSource"
 import { BBox } from "../../BBox"

--- a/Logic/FeatureSource/TiledFeatureSource/DynamicGeoJsonTileSource.ts
+++ b/Logic/FeatureSource/TiledFeatureSource/DynamicGeoJsonTileSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store } from "../../UIEventSource"
 import DynamicTileSource from "./DynamicTileSource"
 import { Utils } from "../../../Utils"

--- a/Logic/FeatureSource/TiledFeatureSource/DynamicTileSource.ts
+++ b/Logic/FeatureSource/TiledFeatureSource/DynamicTileSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, Stores } from "../../UIEventSource"
 import { Tiles } from "../../../Models/TileRange"
 import { BBox } from "../../BBox"

--- a/Logic/FeatureSource/TiledFeatureSource/FullNodeDatabaseSource.ts
+++ b/Logic/FeatureSource/TiledFeatureSource/FullNodeDatabaseSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmNode, OsmObject, OsmWay } from "../../Osm/OsmObject"
 import { UIEventSource } from "../../UIEventSource"
 import { BBox } from "../../BBox"

--- a/Logic/FeatureSource/TiledFeatureSource/LocalStorageFeatureSource.ts
+++ b/Logic/FeatureSource/TiledFeatureSource/LocalStorageFeatureSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import DynamicTileSource from "./DynamicTileSource"
 import { Store } from "../../UIEventSource"
 import { BBox } from "../../BBox"

--- a/Logic/GeoOperations.ts
+++ b/Logic/GeoOperations.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { BBox } from "./BBox"
 import * as turf from "@turf/turf"
 import { AllGeoJSON, booleanWithin, Coord } from "@turf/turf"

--- a/Logic/ImageProviders/AllImageProviders.ts
+++ b/Logic/ImageProviders/AllImageProviders.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Mapillary } from "./Mapillary"
 import { WikimediaImageProvider } from "./WikimediaImageProvider"
 import { Imgur } from "./Imgur"

--- a/Logic/ImageProviders/GenericImageProvider.ts
+++ b/Logic/ImageProviders/GenericImageProvider.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ImageProvider, { ProvidedImage } from "./ImageProvider"
 
 export default class GenericImageProvider extends ImageProvider {

--- a/Logic/ImageProviders/ImageProvider.ts
+++ b/Logic/ImageProviders/ImageProvider.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Store, UIEventSource } from "../UIEventSource"
 import BaseUIElement from "../../UI/BaseUIElement"
 import { LicenseInfo } from "./LicenseInfo"

--- a/Logic/ImageProviders/Imgur.ts
+++ b/Logic/ImageProviders/Imgur.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ImageProvider, { ProvidedImage } from "./ImageProvider"
 import BaseUIElement from "../../UI/BaseUIElement"
 import { Utils } from "../../Utils"

--- a/Logic/ImageProviders/ImgurUploader.ts
+++ b/Logic/ImageProviders/ImgurUploader.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import { Imgur } from "./Imgur"
 

--- a/Logic/ImageProviders/LicenseInfo.ts
+++ b/Logic/ImageProviders/LicenseInfo.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 export class LicenseInfo {
     title: string = ""
     artist: string = ""

--- a/Logic/ImageProviders/Mapillary.ts
+++ b/Logic/ImageProviders/Mapillary.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ImageProvider, { ProvidedImage } from "./ImageProvider"
 import BaseUIElement from "../../UI/BaseUIElement"
 import Svg from "../../Svg"

--- a/Logic/ImageProviders/WikidataImageProvider.ts
+++ b/Logic/ImageProviders/WikidataImageProvider.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ImageProvider, { ProvidedImage } from "./ImageProvider"
 import BaseUIElement from "../../UI/BaseUIElement"
 import Svg from "../../Svg"

--- a/Logic/ImageProviders/WikimediaImageProvider.ts
+++ b/Logic/ImageProviders/WikimediaImageProvider.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ImageProvider, { ProvidedImage } from "./ImageProvider"
 import BaseUIElement from "../../UI/BaseUIElement"
 import Svg from "../../Svg"

--- a/Logic/Maproulette.ts
+++ b/Logic/Maproulette.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Constants from "../Models/Constants"
 
 export default class Maproulette {

--- a/Logic/MetaTagging.ts
+++ b/Logic/MetaTagging.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import SimpleMetaTaggers, { MetataggingState, SimpleMetaTagger } from "./SimpleMetaTagger"
 import { ExtraFuncParams, ExtraFunctions, ExtraFuncType } from "./ExtraFunctions"
 import LayerConfig from "../Models/ThemeConfig/LayerConfig"

--- a/Logic/Osm/Actions/ChangeDescription.ts
+++ b/Logic/Osm/Actions/ChangeDescription.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmNode, OsmRelation, OsmWay } from "../OsmObject"
 
 /**

--- a/Logic/Osm/Actions/ChangeLocationAction.ts
+++ b/Logic/Osm/Actions/ChangeLocationAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { ChangeDescription } from "./ChangeDescription"
 import OsmChangeAction from "./OsmChangeAction"
 

--- a/Logic/Osm/Actions/ChangeTagAction.ts
+++ b/Logic/Osm/Actions/ChangeTagAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import OsmChangeAction from "./OsmChangeAction"
 import { ChangeDescription } from "./ChangeDescription"
 import { TagsFilter } from "../../Tags/TagsFilter"

--- a/Logic/Osm/Actions/CreateMultiPolygonWithPointReuseAction.ts
+++ b/Logic/Osm/Actions/CreateMultiPolygonWithPointReuseAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmCreateAction, PreviewableAction } from "./OsmChangeAction"
 import { Tag } from "../../Tags/Tag"
 import { Changes } from "../Changes"

--- a/Logic/Osm/Actions/CreateNewNodeAction.ts
+++ b/Logic/Osm/Actions/CreateNewNodeAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Tag } from "../../Tags/Tag"
 import { OsmCreateAction } from "./OsmChangeAction"
 import { Changes } from "../Changes"

--- a/Logic/Osm/Actions/CreateNewWayAction.ts
+++ b/Logic/Osm/Actions/CreateNewWayAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { ChangeDescription } from "./ChangeDescription"
 import { OsmCreateAction } from "./OsmChangeAction"
 import { Changes } from "../Changes"

--- a/Logic/Osm/Actions/CreateWayWithPointReuseAction.ts
+++ b/Logic/Osm/Actions/CreateWayWithPointReuseAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmCreateAction, PreviewableAction } from "./OsmChangeAction"
 import { Tag } from "../../Tags/Tag"
 import { Changes } from "../Changes"

--- a/Logic/Osm/Actions/DeleteAction.ts
+++ b/Logic/Osm/Actions/DeleteAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmObject } from "../OsmObject"
 import OsmChangeAction from "./OsmChangeAction"
 import { Changes } from "../Changes"

--- a/Logic/Osm/Actions/OsmChangeAction.ts
+++ b/Logic/Osm/Actions/OsmChangeAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * An action is a change to the OSM-database
  * It will generate some new/modified/deleted objects, which are all bundled by the 'changes'-object

--- a/Logic/Osm/Actions/RelationSplitHandler.ts
+++ b/Logic/Osm/Actions/RelationSplitHandler.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import OsmChangeAction from "./OsmChangeAction"
 import { Changes } from "../Changes"
 import { ChangeDescription } from "./ChangeDescription"

--- a/Logic/Osm/Actions/ReplaceGeometryAction.ts
+++ b/Logic/Osm/Actions/ReplaceGeometryAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import OsmChangeAction, { PreviewableAction } from "./OsmChangeAction"
 import { Changes } from "../Changes"
 import { ChangeDescription } from "./ChangeDescription"

--- a/Logic/Osm/Actions/SplitAction.ts
+++ b/Logic/Osm/Actions/SplitAction.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmWay } from "../OsmObject"
 import { Changes } from "../Changes"
 import { GeoOperations } from "../../GeoOperations"

--- a/Logic/Osm/Changes.ts
+++ b/Logic/Osm/Changes.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { OsmNode, OsmObject, OsmRelation, OsmWay } from "./OsmObject"
 import { Store, UIEventSource } from "../UIEventSource"
 import Constants from "../../Models/Constants"

--- a/Logic/Osm/ChangesetHandler.ts
+++ b/Logic/Osm/ChangesetHandler.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import escapeHtml from "escape-html"
 import UserDetails, { OsmConnection } from "./OsmConnection"
 import { Store, UIEventSource } from "../UIEventSource"

--- a/Logic/Osm/Geocoding.ts
+++ b/Logic/Osm/Geocoding.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 import { BBox } from "../BBox"
 

--- a/Logic/Osm/OsmConnection.ts
+++ b/Logic/Osm/OsmConnection.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import osmAuth from "osm-auth"
 import { Store, Stores, UIEventSource } from "../UIEventSource"
 import { OsmPreferences } from "./OsmPreferences"

--- a/Logic/Osm/OsmObject.ts
+++ b/Logic/Osm/OsmObject.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils";
 import polygon_features from "../../assets/polygon-features.json";
 import { OsmFeature, OsmId, OsmTags, WayId } from "../../Models/OsmFeature";

--- a/Logic/Osm/OsmObjectDownloader.ts
+++ b/Logic/Osm/OsmObjectDownloader.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 import { OsmNode, OsmObject, OsmRelation, OsmWay } from "./OsmObject"
 import { NodeId, OsmId, RelationId, WayId } from "../../Models/OsmFeature"

--- a/Logic/Osm/OsmPreferences.ts
+++ b/Logic/Osm/OsmPreferences.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import UserDetails, { OsmConnection } from "./OsmConnection"
 import { Utils } from "../../Utils"

--- a/Logic/Osm/Overpass.ts
+++ b/Logic/Osm/Overpass.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { TagsFilter } from "../Tags/TagsFilter"
 import { Utils } from "../../Utils"
 import { ImmutableStore, Store } from "../UIEventSource"

--- a/Logic/Osm/aspectedRouting.ts
+++ b/Logic/Osm/aspectedRouting.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 export default class AspectedRouting {
     public readonly name: string
     public readonly description: string

--- a/Logic/SimpleMetaTagger.ts
+++ b/Logic/SimpleMetaTagger.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { GeoOperations } from "./GeoOperations"
 import { Utils } from "../Utils"
 import opening_hours from "opening_hours"

--- a/Logic/State/FeatureSwitchState.ts
+++ b/Logic/State/FeatureSwitchState.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * The part of the global state which initializes the feature switches, based on default values and on the layoutToUse
  */

--- a/Logic/State/GeoLocationState.ts
+++ b/Logic/State/GeoLocationState.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import { LocalStorageSource } from "../Web/LocalStorageSource"
 import { QueryParameters } from "../Web/QueryParameters"

--- a/Logic/State/LayerState.ts
+++ b/Logic/State/LayerState.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import { GlobalFilter } from "../../Models/GlobalFilter"
 import FilteredLayer from "../../Models/FilteredLayer"

--- a/Logic/State/UserRelatedState.ts
+++ b/Logic/State/UserRelatedState.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import LayoutConfig from "../../Models/ThemeConfig/LayoutConfig"
 import { OsmConnection } from "../Osm/OsmConnection"
 import { MangroveIdentity } from "../Web/MangroveReviews"

--- a/Logic/Tags/And.ts
+++ b/Logic/Tags/And.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { TagsFilter } from "./TagsFilter"
 import { Or } from "./Or"
 import { TagUtils } from "./TagUtils"

--- a/Logic/Tags/ComparingTag.ts
+++ b/Logic/Tags/ComparingTag.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { TagsFilter } from "./TagsFilter"
 
 export default class ComparingTag implements TagsFilter {

--- a/Logic/Tags/Or.ts
+++ b/Logic/Tags/Or.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { TagsFilter } from "./TagsFilter"
 import { TagUtils } from "./TagUtils"
 import { And } from "./And"

--- a/Logic/Tags/RegexTag.ts
+++ b/Logic/Tags/RegexTag.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Tag } from "./Tag"
 import { TagsFilter } from "./TagsFilter"
 

--- a/Logic/Tags/SubstitutingTag.ts
+++ b/Logic/Tags/SubstitutingTag.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { TagsFilter } from "./TagsFilter"
 import { Tag } from "./Tag"
 import { Utils } from "../../Utils"

--- a/Logic/Tags/Tag.ts
+++ b/Logic/Tags/Tag.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 import { TagsFilter } from "./TagsFilter"
 

--- a/Logic/Tags/TagUtils.ts
+++ b/Logic/Tags/TagUtils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Tag } from "./Tag"
 import { TagsFilter } from "./TagsFilter"
 import { And } from "./And"

--- a/Logic/Tags/TagsFilter.ts
+++ b/Logic/Tags/TagsFilter.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 export abstract class TagsFilter {
     abstract asOverpass(): string[]
 

--- a/Logic/UIEventSource.ts
+++ b/Logic/UIEventSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../Utils"
 import { Readable, Subscriber, Unsubscriber, Updater, Writable } from "svelte/store"
 

--- a/Logic/Web/Hash.ts
+++ b/Logic/Web/Hash.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import { Utils } from "../../Utils"
 

--- a/Logic/Web/IdbLocalStorage.ts
+++ b/Logic/Web/IdbLocalStorage.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import * as idb from "idb-keyval"
 import { Utils } from "../../Utils"

--- a/Logic/Web/LiveQueryHandler.ts
+++ b/Logic/Web/LiveQueryHandler.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 import { Utils } from "../../Utils"
 

--- a/Logic/Web/LocalStorageSource.ts
+++ b/Logic/Web/LocalStorageSource.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { UIEventSource } from "../UIEventSource"
 
 /**

--- a/Logic/Web/MangroveReviews.ts
+++ b/Logic/Web/MangroveReviews.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { ImmutableStore, Store, UIEventSource } from "../UIEventSource"
 import { MangroveReviews, Review } from "mangrove-reviews-typescript"
 import { Utils } from "../../Utils"

--- a/Logic/Web/PlantNet.ts
+++ b/Logic/Web/PlantNet.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 
 export default class PlantNet {

--- a/Logic/Web/QueryParameters.ts
+++ b/Logic/Web/QueryParameters.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Wraps the query parameters into UIEventSources
  */

--- a/Logic/Web/ThemeViewStateHashActor.ts
+++ b/Logic/Web/ThemeViewStateHashActor.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ThemeViewState from "../../Models/ThemeViewState"
 import Hash from "./Hash"
 

--- a/Logic/Web/Wikidata.ts
+++ b/Logic/Web/Wikidata.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 import { Store, UIEventSource } from "../UIEventSource"
 import * as wds from "wikidata-sdk"

--- a/Logic/Web/Wikimedia.ts
+++ b/Logic/Web/Wikimedia.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 
 export default class Wikimedia {

--- a/Logic/Web/Wikipedia.ts
+++ b/Logic/Web/Wikipedia.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { Utils } from "../../Utils"
 import Wikidata, { WikidataResponse } from "./Wikidata"
 import { Store, UIEventSource } from "../UIEventSource"

--- a/Utils/LanguageUtils.ts
+++ b/Utils/LanguageUtils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import used_languages from "../assets/used_languages.json"
 
 export default class LanguageUtils {

--- a/Utils/WikidataUtils.ts
+++ b/Utils/WikidataUtils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 export default class WikidataUtils {
     /**
      * Mapping from wikidata-codes to weblate-codes. The wikidata-code is the key, mapcomplete/weblate is the value

--- a/Utils/pngMapCreator.ts
+++ b/Utils/pngMapCreator.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ThemeViewState from "../Models/ThemeViewState"
 import { Utils } from "../Utils"
 import { UIEventSource } from "../Logic/UIEventSource"

--- a/Utils/svgToPdf.ts
+++ b/Utils/svgToPdf.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import jsPDF, { Matrix } from "jspdf"
 import { Translation, TypedTranslation } from "../UI/i18n/Translation"
 import { PngMapCreator } from "./pngMapCreator"

--- a/assets/SocialImageBanner.svg.license
+++ b/assets/SocialImageBanner.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/SocialImageRepo.svg.license
+++ b/assets/SocialImageRepo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/SocialImageTemplate.svg.license
+++ b/assets/SocialImageTemplate.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/SocialImageTemplateWide.svg.license
+++ b/assets/SocialImageTemplateWide.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/SocialImageForeground.svg.license
+++ b/assets/svg/SocialImageForeground.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/add.svg.license
+++ b/assets/svg/add.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/addSmall.svg.license
+++ b/assets/svg/addSmall.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/add_pin.svg.license
+++ b/assets/svg/add_pin.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/back.svg.license
+++ b/assets/svg/back.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/blocked.svg.license
+++ b/assets/svg/blocked.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/brick_wall_raw.svg.license
+++ b/assets/svg/brick_wall_raw.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/brick_wall_round.svg.license
+++ b/assets/svg/brick_wall_round.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/brick_wall_square.svg.license
+++ b/assets/svg/brick_wall_square.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/bug.svg.license
+++ b/assets/svg/bug.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/camera-plus.svg.license
+++ b/assets/svg/camera-plus.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/checkmark.svg.license
+++ b/assets/svg/checkmark.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/circle.svg.license
+++ b/assets/svg/circle.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/clock.svg.license
+++ b/assets/svg/clock.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/close.svg.license
+++ b/assets/svg/close.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/community.svg.license
+++ b/assets/svg/community.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/compass.svg.license
+++ b/assets/svg/compass.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/confirm.svg.license
+++ b/assets/svg/confirm.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/copyright.svg.license
+++ b/assets/svg/copyright.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/cross_bottom_right.svg.license
+++ b/assets/svg/cross_bottom_right.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/crosshair-locked.svg.license
+++ b/assets/svg/crosshair-locked.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/crosshair.svg.license
+++ b/assets/svg/crosshair.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/delete_icon.svg.license
+++ b/assets/svg/delete_icon.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/delete_not_allowed.svg.license
+++ b/assets/svg/delete_not_allowed.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/direction_gradient.svg.license
+++ b/assets/svg/direction_gradient.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/direction_stroke.svg.license
+++ b/assets/svg/direction_stroke.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/download.svg.license
+++ b/assets/svg/download.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/duplicate.svg.license
+++ b/assets/svg/duplicate.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/elevator.svg.license
+++ b/assets/svg/elevator.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/elevator_wheelchair.svg.license
+++ b/assets/svg/elevator_wheelchair.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/envelope.svg.license
+++ b/assets/svg/envelope.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/eye.svg.license
+++ b/assets/svg/eye.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/filter.svg.license
+++ b/assets/svg/filter.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/filter_disable.svg.license
+++ b/assets/svg/filter_disable.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/floppy.svg.license
+++ b/assets/svg/floppy.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gear.svg.license
+++ b/assets/svg/gear.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_bi.svg.license
+++ b/assets/svg/gender_bi.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_female.svg.license
+++ b/assets/svg/gender_female.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_inter.svg.license
+++ b/assets/svg/gender_inter.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_male.svg.license
+++ b/assets/svg/gender_male.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_queer.svg.license
+++ b/assets/svg/gender_queer.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gender_trans.svg.license
+++ b/assets/svg/gender_trans.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/generic_map.svg.license
+++ b/assets/svg/generic_map.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/gps_arrow.svg.license
+++ b/assets/svg/gps_arrow.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/hand.svg.license
+++ b/assets/svg/hand.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/help.svg.license
+++ b/assets/svg/help.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/home.svg.license
+++ b/assets/svg/home.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/invalid.svg.license
+++ b/assets/svg/invalid.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/josm_logo.svg.license
+++ b/assets/svg/josm_logo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/layers.svg.license
+++ b/assets/svg/layers.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/length-crosshair.svg.license
+++ b/assets/svg/length-crosshair.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/liberapay.svg.license
+++ b/assets/svg/liberapay.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/loading.svg.license
+++ b/assets/svg/loading.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/location-empty.svg.license
+++ b/assets/svg/location-empty.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/location-refused.svg.license
+++ b/assets/svg/location-refused.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/location.svg.license
+++ b/assets/svg/location.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/location_locked.svg.license
+++ b/assets/svg/location_locked.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/location_unlocked.svg.license
+++ b/assets/svg/location_unlocked.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/login.svg.license
+++ b/assets/svg/login.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/logo.svg.license
+++ b/assets/svg/logo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/logout.svg.license
+++ b/assets/svg/logout.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/mapcomplete_logo.svg.license
+++ b/assets/svg/mapcomplete_logo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/mapillary.svg.license
+++ b/assets/svg/mapillary.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/mapillary_black.svg.license
+++ b/assets/svg/mapillary_black.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/mastodon.svg.license
+++ b/assets/svg/mastodon.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/min.svg.license
+++ b/assets/svg/min.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/move-arrows.svg.license
+++ b/assets/svg/move-arrows.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/move.svg.license
+++ b/assets/svg/move.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/move_confirm.svg.license
+++ b/assets/svg/move_confirm.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/move_not_allowed.svg.license
+++ b/assets/svg/move_not_allowed.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/no_checkmark.svg.license
+++ b/assets/svg/no_checkmark.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/none.svg.license
+++ b/assets/svg/none.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/not_found.svg.license
+++ b/assets/svg/not_found.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/note.svg.license
+++ b/assets/svg/note.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/osm-logo-us.svg.license
+++ b/assets/svg/osm-logo-us.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/osm-logo.svg.license
+++ b/assets/svg/osm-logo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/party.svg.license
+++ b/assets/svg/party.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/pencil.svg.license
+++ b/assets/svg/pencil.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/person.svg.license
+++ b/assets/svg/person.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/pin.svg.license
+++ b/assets/svg/pin.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/plantnet_logo.svg.license
+++ b/assets/svg/plantnet_logo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/plus.svg.license
+++ b/assets/svg/plus.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/pop-out.svg.license
+++ b/assets/svg/pop-out.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/reload.svg.license
+++ b/assets/svg/reload.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/relocation.svg.license
+++ b/assets/svg/relocation.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/resolved.svg.license
+++ b/assets/svg/resolved.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/ring.svg.license
+++ b/assets/svg/ring.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/robot.svg.license
+++ b/assets/svg/robot.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/satellite.svg.license
+++ b/assets/svg/satellite.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/scissors.svg.license
+++ b/assets/svg/scissors.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/search.svg.license
+++ b/assets/svg/search.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/search_disable.svg.license
+++ b/assets/svg/search_disable.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/share.svg.license
+++ b/assets/svg/share.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/speech_bubble.svg.license
+++ b/assets/svg/speech_bubble.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/speech_bubble_black_outline.svg.license
+++ b/assets/svg/speech_bubble_black_outline.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/square.svg.license
+++ b/assets/svg/square.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/star.svg.license
+++ b/assets/svg/star.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/star_half.svg.license
+++ b/assets/svg/star_half.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/star_outline.svg.license
+++ b/assets/svg/star_outline.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/star_outline_half.svg.license
+++ b/assets/svg/star_outline_half.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/statistics.svg.license
+++ b/assets/svg/statistics.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/teardrop.svg.license
+++ b/assets/svg/teardrop.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/teardrop_with_hole_green.svg.license
+++ b/assets/svg/teardrop_with_hole_green.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/translate.svg.license
+++ b/assets/svg/translate.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/triangle.svg.license
+++ b/assets/svg/triangle.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/up.svg.license
+++ b/assets/svg/up.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/upload.svg.license
+++ b/assets/svg/upload.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/wikidata.svg.license
+++ b/assets/svg/wikidata.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/wikimedia-commons-white.svg.license
+++ b/assets/svg/wikimedia-commons-white.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/svg/wikipedia.svg.license
+++ b/assets/svg/wikipedia.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/assets/weblogo.svg.license
+++ b/assets/weblogo.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>

--- a/scripts/BuildMeta.ts
+++ b/scripts/BuildMeta.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import Validators from "../UI/InputElement/Validators"
 

--- a/scripts/CycleHighwayFix.ts
+++ b/scripts/CycleHighwayFix.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 import { appendFileSync, readFileSync, writeFileSync } from "fs"
 import OsmObjectDownloader from "../Logic/Osm/OsmObjectDownloader"

--- a/scripts/GenerateSeries.ts
+++ b/scripts/GenerateSeries.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "fs"
 import ScriptUtils from "./ScriptUtils"
 import { Utils } from "../Utils"

--- a/scripts/Script.ts
+++ b/scripts/Script.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 
 export default abstract class Script {

--- a/scripts/ScriptUtils.ts
+++ b/scripts/ScriptUtils.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { existsSync, lstatSync, readdirSync, readFileSync } from "fs"
 import { Utils } from "../Utils"

--- a/scripts/automoveTranslations.ts
+++ b/scripts/automoveTranslations.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { readFileSync, writeFileSync } from "fs"
 
 /**

--- a/scripts/conflate.ts
+++ b/scripts/conflate.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import fs from "fs"
 import { Feature } from "geojson"

--- a/scripts/csvToGeojson.ts
+++ b/scripts/csvToGeojson.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { parse } from "csv-parse/sync"
 import { readFileSync } from "fs"
 

--- a/scripts/downloadEli.ts
+++ b/scripts/downloadEli.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import { Utils } from "../Utils"
 import { FeatureCollection } from "geojson"

--- a/scripts/downloadFile.ts
+++ b/scripts/downloadFile.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 const http = require("https")
 const fs = require("fs")
 

--- a/scripts/downloadFromOverpass.ts
+++ b/scripts/downloadFromOverpass.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import { TagUtils } from "../Logic/Tags/TagUtils"
 import { And } from "../Logic/Tags/And"

--- a/scripts/extractLayer.ts
+++ b/scripts/extractLayer.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { LayoutConfigJson } from "../Models/ThemeConfig/Json/LayoutConfigJson"
 import { LayerConfigJson } from "../Models/ThemeConfig/Json/LayerConfigJson"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"

--- a/scripts/fetchLanguages.ts
+++ b/scripts/fetchLanguages.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Fetches all 'modern languages' from wikidata, then exports their names in every language.
  * Some meta-info (e.g. RTL) is exported too

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { TagUtils } from "../Logic/Tags/TagUtils"
 import { writeFileSync } from "fs"

--- a/scripts/fixImagesInTagRenderings.ts
+++ b/scripts/fixImagesInTagRenderings.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { readFileSync, writeFileSync } from "fs"
 import { DesugaringStep } from "../Models/ThemeConfig/Conversion/Conversion"
 import { LayerConfigJson } from "../Models/ThemeConfig/Json/LayerConfigJson"

--- a/scripts/fixQuestionHint.ts
+++ b/scripts/fixQuestionHint.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { DesugaringStep } from "../Models/ThemeConfig/Conversion/Conversion"
 import { LayerConfigJson } from "../Models/ThemeConfig/Json/LayerConfigJson"

--- a/scripts/fixSchemas.ts
+++ b/scripts/fixSchemas.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 import { readFileSync, writeFileSync } from "fs"
 

--- a/scripts/generateCache.ts
+++ b/scripts/generateCache.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Generates a collection of geojson files based on an overpass query for a given theme
  */

--- a/scripts/generateContributors.ts
+++ b/scripts/generateContributors.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { exec } from "child_process"
 import { writeFileSync } from "fs"
 

--- a/scripts/generateDocs.ts
+++ b/scripts/generateDocs.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Combine from "../UI/Base/Combine"
 import BaseUIElement from "../UI/BaseUIElement"
 import { existsSync, mkdirSync, writeFile, writeFileSync } from "fs"

--- a/scripts/generateImageAnalysis.ts
+++ b/scripts/generateImageAnalysis.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import { Overpass } from "../Logic/Osm/Overpass"
 import { RegexTag } from "../Logic/Tags/RegexTag"

--- a/scripts/generateIncludedImages.ts
+++ b/scripts/generateIncludedImages.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 
 function genImages(dryrun = false) {

--- a/scripts/generateLayerOverview.ts
+++ b/scripts/generateLayerOverview.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs"
 import licenses from "../assets/generated/license_info.json"

--- a/scripts/generateLayouts.ts
+++ b/scripts/generateLayouts.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFile, writeFileSync } from "fs"
 import Locale from "../UI/i18n/Locale"
 import Translations from "../UI/i18n/Translations"

--- a/scripts/generateLicenseInfo.ts
+++ b/scripts/generateLicenseInfo.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs"
 import SmallLicense from "../Models/smallLicense"
 import ScriptUtils from "./ScriptUtils"

--- a/scripts/generateReviewsAnalysis.ts
+++ b/scripts/generateReviewsAnalysis.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import Script from "./Script"
 import * as fs from "fs"
 import { Review } from "mangrove-reviews-typescript"

--- a/scripts/generateStats.ts
+++ b/scripts/generateStats.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import known_layers from "../assets/generated/known_layers.json"
 import { LayerConfigJson } from "../Models/ThemeConfig/Json/LayerConfigJson"
 import { TagUtils } from "../Logic/Tags/TagUtils"

--- a/scripts/generateTaginfoProjectFiles.ts
+++ b/scripts/generateTaginfoProjectFiles.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { AllKnownLayouts } from "../Customizations/AllKnownLayouts"
 import Locale from "../UI/i18n/Locale"
 import { Translation } from "../UI/i18n/Translation"

--- a/scripts/generateTileOverview.ts
+++ b/scripts/generateTileOverview.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Generates an overview for which tiles exist and which don't
  */

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
 import { Utils } from "../Utils"

--- a/scripts/importscripts/cash.ts
+++ b/scripts/importscripts/cash.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import fs from "fs"
 import { OH } from "../../UI/OpeningHours/OpeningHours"
 

--- a/scripts/importscripts/extractBikeRental.ts
+++ b/scripts/importscripts/extractBikeRental.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { OH } from "../../UI/OpeningHours/OpeningHours"
 

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 import { writeFileSync } from "fs"
 import {

--- a/scripts/makeConvex.ts
+++ b/scripts/makeConvex.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import fs from "fs"
 import { GeoOperations } from "../Logic/GeoOperations"
 import ScriptUtils from "./ScriptUtils"

--- a/scripts/mergeJsonFiles.ts
+++ b/scripts/mergeJsonFiles.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { readFileSync, writeFileSync } from "fs"
 import { Utils } from "../Utils"
 

--- a/scripts/onwheels/constants.ts
+++ b/scripts/onwheels/constants.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /**
  * Class containing all constants and tables used in the script
  *

--- a/scripts/onwheels/convertData.ts
+++ b/scripts/onwheels/convertData.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { parse } from "csv-parse/sync"
 import { readFileSync, writeFileSync } from "fs"
 import { Feature, FeatureCollection, GeoJsonProperties } from "geojson"

--- a/scripts/perProperty.ts
+++ b/scripts/perProperty.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 
 function main(args) {

--- a/scripts/postal_code_tools/createRoutablePoint.ts
+++ b/scripts/postal_code_tools/createRoutablePoint.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "fs"
 import { GeoOperations } from "../../Logic/GeoOperations"
 import ScriptUtils from "../ScriptUtils"

--- a/scripts/postal_code_tools/genPostal.sh
+++ b/scripts/postal_code_tools/genPostal.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+#
+# SPDX-License-Identifier: GPL-3.0-ONLY
+
 # npm run generate:layeroverview
 cd ../..
 ts-node scripts/generateCache.ts postal_codes 8 /home/pietervdvn/Downloads/postal_codes 49.69606181911566 2.373046875 51.754240074033525 6.459960937499999 --generate-point-overview '*' --force-zoom-level 1

--- a/scripts/postal_code_tools/genWallonia.sh
+++ b/scripts/postal_code_tools/genWallonia.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+#
+# SPDX-License-Identifier: GPL-3.0-ONLY
+
 # Generates data for the wallonia address dataset: convex hulls for postal code outlines, tiled address files for import
 
 wget https://opendata.bosa.be/download/best/openaddress-bewal.zip

--- a/scripts/postal_code_tools/knownPostalCodes.csv.license
+++ b/scripts/postal_code_tools/knownPostalCodes.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+
+SPDX-License-Identifier: GPL-3.0-ONLY

--- a/scripts/postal_code_tools/openaddressestogeojson.ts
+++ b/scripts/postal_code_tools/openaddressestogeojson.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { existsSync, writeFileSync } from "fs"
 import * as readline from "readline"

--- a/scripts/postal_code_tools/prepPostalCodesHulls.ts
+++ b/scripts/postal_code_tools/prepPostalCodesHulls.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import { writeFileSync } from "fs"
 import ScriptUtils from "../ScriptUtils"

--- a/scripts/removeTranslationString.ts
+++ b/scripts/removeTranslationString.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import ScriptUtils from "./ScriptUtils"
 import { Utils } from "../Utils"
 import * as fs from "fs"

--- a/scripts/slice.ts
+++ b/scripts/slice.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 import * as fs from "fs"
 import StaticFeatureSource from "../Logic/FeatureSource/Sources/StaticFeatureSource"
 import * as readline from "readline"

--- a/scripts/thieves/readIdPresets.ts
+++ b/scripts/thieves/readIdPresets.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 MapComplete  <https://mapcomplete.osm.be/>
+//
+// SPDX-License-Identifier: GPL-3.0-ONLY
+
 /***
  * Parses presets from the iD repository and extracts some usefull tags from them
  */


### PR DESCRIPTION
Hello,

By way of introduction, I am Jithendra with the Free Software Foundation Europe, a consortium member of the NGI0 Initiative, of which you have signed MapComplete up for participation and funding. Part of what is offered with your involvement with NGI0 is help from us with your project on your copyright and license management.

After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information in your files. Our REUSE specification (https://reuse.software) intends to make licensing easier with best practices to display legal information through comment headers on source files that can be easily human and machine readable. The REUSE tool makes the process of applying licenses to files and compliance checking much easier.

Instructions on how to install the REUSE tool can be found here: https://reuse.readthedocs.io/en/stable/readme.html#install

You can also check out this screencast for more instructions on how to use the REUSE tool: https://download.fsfe.org/videos/reuse/screencasts/reuse-tool.gif

The changes in this pull request have also been made for you to understand the basic ideas behind REUSE, and how adopting the REUSE practices would look like within your repository.

# REUSE Features:
• SPDX copyright and license comment headers for relevant files.
• LICENSES directory with licenses used in the repository
• Associating copyright/licensing information through a DEP5 file in large directories.

# Files Missing Copyright and Licensing Information
I've noticed that several files in your repository already contain information about the copyright and license information for the code in that particular file. That's great! Nevertheless, the idea behind REUSE is that every single file in your repository should have a header that includes this information.

To serve as an example, I added the SPDX headers with copyright and license information to the copyrightable files in a few of the directories (namely all the ".ts" files in the /scripts folder  /Logic folder and /Utils folder). This should give you an idea of how comment headers should look like in a REUSE compliant repository, and how they should be added to the other source code files in your repository.

Please also check if the personal information in these headers are correct and consistent to your knowledge. In the event that there are more copyright holders, please include them in these comment headers.

## LICENSES Directory in the Root of the Project Repository
The LICENSES Folder should contain the license text of every license applicable in your repository. I included in this directory the file that contained the GPL 3.0 license text.

Additionally, I included in this folder the text for the CC0 license. This is because you have files in your project that are not copyrightable, for example configuration files such as .gitignore. As the fundamental idea of REUSE is that all of your files will clearly have their copyright and licensing marked, I have applied the CC0 license to .gitignore, which is functionally identical to putting the file into the public domain.

## Image files 
Additionally, I noticed that you have several image files ".svg" in the Assets folder. For image files, we recommend creating a .license file, where you can include the comment headers for the license and copyright information. We've added comment headers to all the .svg files in svg folder and here listing the project MapComplete as the copyright holder. Please feel free to modify this to your needs.

I hope that you find this useful. Feel free to adopt in case you feel REUSE may help your project with copyright and licensing management. Please feel free to contact me directly at jithendra@fsfe.org if you have any questions.


Best,
Jithendra
(Free Software Foundation Europe)

