### PR TITLE
Fix/penny press

### DIFF
--- a/assets/layers/filters/filters.json
+++ b/assets/layers/filters/filters.json
@@ -56,6 +56,28 @@
       ]
     },
     {
+      "id": "accepts_debit_cards",
+      "options": [
+        {
+          "osmTags": "payment:debit_cards=yes",
+          "question": {
+            "en": "Accepts debit cards"
+          }
+        }
+      ]
+    },
+    {
+      "id": "accepts_credit_cards",
+      "options": [
+        {
+          "osmTags": "payment:credit_cards=yes",
+          "question": {
+            "en": "Accepts credit cards"
+          }
+        }
+      ]
+    },
+    {
       "id": "has_image",
       "options": [
         {

--- a/assets/layers/questions/questions.json
+++ b/assets/layers/questions/questions.json
@@ -2174,6 +2174,33 @@
           }
         }
       ]
+    },
+    {
+      "id": "check_date",
+      "question": {
+        "en": "When was this object last checked?",
+        "de": "Wann wurde dieses Objekt zuletzt kontrolliert?",
+        "nl": "Wanneer is dit object voor het laatst gecontroleerd?"
+      },
+      "freeform": {
+        "key": "check_date",
+        "type": "date"
+      },
+      "render": {
+        "en": "This object was last checked on <b>{check_date}</b>",
+        "de": "Dieses Objekt wurde zuletzt kontrolliert am <b>{check_date}</b>",
+        "nl": "Dit object is voor het laatst gecontroleerd op <b>{check_date}</b>"
+      },
+      "mappings": [
+        {
+          "if": "check_date:={_now:date}",
+          "then": {
+            "en": "This object was last checked today",
+            "de": "Dieses Objekt wurde heute zuletzt kontrolliert",
+            "nl": "Dit object is vandaag voor het laatst gecontroleerd"
+          }
+        }
+      ]
     }
   ]
 }

--- a/assets/themes/elongated_coin/elongated_coin.json
+++ b/assets/themes/elongated_coin/elongated_coin.json
@@ -86,21 +86,7 @@
             }
           ]
         },
-        {
-          "id": "payment",
-          "builtin": "payment-options-split",
-          "override": {
-            "mappings": [
-              {},
-              {},
-              {},
-              {},
-              {
-                "hideInAnswer": true
-              }
-            ]
-          }
-        },
+        "payment-options-split",
         {
           "id": "coin",
           "question": {
@@ -257,7 +243,9 @@
       },
       "deletion": true,
       "filter": [
-        "open_now"
+        "open_now",
+        "accepts_debit_cards",
+        "accepts_credit_cards"
       ]
     }
   ],

--- a/assets/themes/elongated_coin/elongated_coin.json
+++ b/assets/themes/elongated_coin/elongated_coin.json
@@ -87,6 +87,21 @@
           ]
         },
         {
+          "id": "payment",
+          "builtin": "payment-options-split",
+          "override": {
+            "mappings": [
+              {},
+              {},
+              {},
+              {},
+              {
+                "hideInAnswer": true
+              }
+            ]
+          }
+        },
+        {
           "id": "coin",
           "question": {
             "en": "What coin is used for pressing?",
@@ -205,7 +220,8 @@
             }
           ]
         },
-        "level"
+        "level",
+        "check_date"
       ],
       "mapRendering": [
         {
@@ -235,6 +251,11 @@
           ]
         }
       ],
+      "allowMove": {
+        "enableImproveAccuracy": true,
+        "enableRelocation": true
+      },
+      "deletion": true,
       "filter": [
         "open_now"
       ]


### PR DESCRIPTION
* Adds payment methods, since there are some that actually accept cards and don't even need a coin.
* Adds filters for them
* Add question for check_date (seems to be more popular for this usecase)

Might have to figure out some tagging for souvenir bank notes and other souvenir coins sometime...