### PR TITLE
modified charging_station layer to have kW, MW order

### DIFF
--- a/assets/layers/charging_station/charging_station.json
+++ b/assets/layers/charging_station/charging_station.json
@@ -3140,8 +3140,8 @@
       "socket:schuko:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:typee:voltage": "voltage",
@@ -3149,8 +3149,8 @@
       "socket:typee:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:chademo:voltage": "voltage",
@@ -3158,8 +3158,8 @@
       "socket:chademo:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type1_cable:voltage": "voltage",
@@ -3167,8 +3167,8 @@
       "socket:type1_cable:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type1:voltage": "voltage",
@@ -3176,8 +3176,8 @@
       "socket:type1:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type1_combo:voltage": "voltage",
@@ -3185,8 +3185,8 @@
       "socket:type1_combo:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:tesla_supercharger:voltage": "voltage",
@@ -3194,8 +3194,8 @@
       "socket:tesla_supercharger:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type2:voltage": "voltage",
@@ -3203,8 +3203,8 @@
       "socket:type2:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type2_combo:voltage": "voltage",
@@ -3212,8 +3212,8 @@
       "socket:type2_combo:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:type2_cable:voltage": "voltage",
@@ -3221,8 +3221,8 @@
       "socket:type2_cable:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:tesla_supercharger_ccs:voltage": "voltage",
@@ -3230,8 +3230,8 @@
       "socket:tesla_supercharger_ccs:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:tesla_destination:voltage": "voltage",
@@ -3239,8 +3239,8 @@
       "socket:tesla_destination:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:USB-A:voltage": "voltage",
@@ -3248,8 +3248,8 @@
       "socket:USB-A:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:bosch_3pin:voltage": "voltage",
@@ -3257,8 +3257,8 @@
       "socket:bosch_3pin:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:bosch_5pin:voltage": "voltage",
@@ -3266,8 +3266,8 @@
       "socket:bosch_5pin:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:bs1363:voltage": "voltage",
@@ -3275,8 +3275,8 @@
       "socket:bs1363:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:nema5_15:voltage": "voltage",
@@ -3284,8 +3284,8 @@
       "socket:nema5_15:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:sev1011_t23:voltage": "voltage",
@@ -3293,8 +3293,8 @@
       "socket:sev1011_t23:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:as3112:voltage": "voltage",
@@ -3302,8 +3302,8 @@
       "socket:as3112:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       },
       "socket:nema_5_20:voltage": "voltage",
@@ -3311,8 +3311,8 @@
       "socket:nema_5_20:output": {
         "quantity": "power",
         "denominations": [
-          "mW",
-          "kW"
+          "kW",
+          "MW"
         ]
       }
     }


### PR DESCRIPTION
originally it showed MW by default for a charger, which is ... almost unheard of except for very new truck chargers and those barely exist. Plus I fixed mW to MW which is the correct capitalization

Opening a pull request on MapComplete
=====================================

Hey! Thanks for opening a pull request on Mapcomplete! This probably means you want to add a new theme - if so, please
follow the checklist below. If this pull request is for some other issue, please ignore the template.

Adding your new theme
---------------------

Thanks for taking the time to create your theme and to add it to the main repository!

To making merging smooth, please make sure that each of the following conditions is met:

- [x] The codebase is GPL-licensed. By opening a pull request, the new theme will be GPL too
- [x] All images are included in the pull request and no images are loaded from an external service (e.g. Wikipedia)
- [x] The [guidelines on how to make your own theme](https://github.com/pietervdvn/MapComplete/blob/master/Docs/Making_Your_Own_Theme.md)
  are read and followed
