### PR TITLE
Correct typo 'firepitd' in firepit.json

### DIFF
--- a/assets/layers/firepit/firepit.json
+++ b/assets/layers/firepit/firepit.json
@@ -1,7 +1,7 @@
 {
   "id": "firepit",
   "name": {
-    "en": "Firepitd",
+    "en": "Firepit",
     "de": "Feuerstelle"
   },
   "description": {


### PR DESCRIPTION
Corrects typo 'firepitd'.

(Reminder: this typo propagates to the docs. Please reload them when time permits. I personally only use GitHub browser and don't/can't do any such changes directly.)