### PR TITLE
Correct typo 'initing'

### DIFF
--- a/src/Models/ThemeConfig/TagRenderingConfig.ts
+++ b/src/Models/ThemeConfig/TagRenderingConfig.ts
@@ -88,7 +88,7 @@ export default class TagRenderingConfig {
     ) {
         let json = <string | QuestionableTagRenderingConfigJson>config
         if (json === undefined) {
-            throw "Initing a TagRenderingConfig with undefined in " + context
+            throw "Initiating a TagRenderingConfig with undefined in " + context
         }
 
         if (typeof json === "number") {

--- a/src/UI/Map/MaplibreMap.svelte
+++ b/src/UI/Map/MaplibreMap.svelte
@@ -46,7 +46,7 @@
       styleUrl = defaultLayer.style ?? defaultLayer.url
     }
 
-    console.log("Initing mapLIbremap with style", styleUrl)
+    console.log("Initiating mapLIbremap with style", styleUrl)
 
     const options: MapOptions = {
       container,


### PR DESCRIPTION
Corrects typo 'initing'.

Ref #1904.