### PR TITLE
Update artwork.json - Correct copy-paste error in memorial question

### DIFF
--- a/assets/layers/artwork/artwork.json
+++ b/assets/layers/artwork/artwork.json
@@ -814,7 +814,7 @@
           "if": "historic=",
           "alsoShowIf": "historic!=memorial",
           "then": {
-            "en": "This artwork does not serve as a bench",
+            "en": "This artwork does not serve as a memorial",
             "de": "Dieses Kunstwerk dient nicht als Sitzbank",
             "fr": "Cette œuvre ne sert pas de banc",
             "cs": "Toto dílo neslouží jako lavička",


### PR DESCRIPTION
'Artwork does not serve as a memorial'
Corrects copy-paste error from https://github.com/pietervdvn/MapComplete/commit/29c5b884c404c14258dd116921990923c9a89181

---

The question is whether it serves as a memorial, not as a bench. This question is already asked below.
This 'bug' happens on all artworks on both Artworks and Memorials themes.
[The code can be found here](https://github.com/pietervdvn/MapComplete/blob/48dc03b1e6b501ebea007ca6267625c8d55ada60/assets/layers/artwork/artwork.json#L817)

![image](https://github.com/user-attachments/assets/bddcfba8-a7f1-478d-9afb-6b10e0fabd56)

0.47.5 / 0.47.5-dev