### PR TITLE
Add description for horse riding arena in sport_pitch.json

### DIFF
--- a/assets/layers/sport_pitch/sport_pitch.json
+++ b/assets/layers/sport_pitch/sport_pitch.json
@@ -306,6 +306,14 @@
           "hideInAnswer": true
         },
         {
+          "if": "sport=equestrian",
+          "then": {
+            "en": "This is a horse riding arena",
+            "de": "Dies ist ein Reitplatz",
+            "es": "Esta es una pista ecuestre"
+          }
+        },
+        {
           "if": "sport=skateboard",
           "then": {
             "en": "This is a skatepark",

--- a/assets/layers/sport_pitch/sport_pitch.json
+++ b/assets/layers/sport_pitch/sport_pitch.json
@@ -306,14 +306,6 @@
           "hideInAnswer": true
         },
         {
-          "if": "sport=equestrian",
-          "then": {
-            "en": "This is a horse riding arena",
-            "de": "Dies ist ein Reitplatz",
-            "es": "Esta es una pista ecuestre"
-          }
-        },
-        {
           "if": "sport=skateboard",
           "then": {
             "en": "This is a skatepark",
@@ -322,6 +314,14 @@
             "ca": "Açò és un skatepark",
             "cs": "Toto je skatepark",
             "es": "Este es un skatepark"
+          }
+        },
+        {
+          "if": "sport=equestrian",
+          "then": {
+            "en": "This is a horse riding arena",
+            "de": "Dies ist ein Reitplatz",
+            "es": "Esta es una pista ecuestre"
           }
         }
       ],


### PR DESCRIPTION
This adds a decription for a horse riding arena in sport_pitch.json like this:

![mapcomplete](https://github.com/user-attachments/assets/7145e040-d4f2-453a-ac92-7ca7b3a41310)

instead of former text "equestrian is played here".