### PR TITLE
Make data filters work and add presets for skateboard and equestrian …

### DIFF
--- a/assets/layers/sport_pitch/sport_pitch.json
+++ b/assets/layers/sport_pitch/sport_pitch.json
@@ -166,6 +166,28 @@
         "leisure=pitch",
         "fixme=Geometry to be drawn, added by MapComplete"
       ]
+    },
+    {
+      "title": {
+        "en": "a skatepark",
+        "de": "einen Skatepark",
+        "es": "un skatepark"
+      },
+      "tags": [
+        "leisure=pitch",
+        "sport=skateboard"
+      ]
+    },
+    {
+      "title": {
+        "en": "a horse riding arena",
+        "de": "einen Reitplatz",
+        "es": "una pista ecuestre"
+      },
+      "tags": [
+        "leisure=pitch",
+        "sport=equestrian"
+      ]
     }
   ],
   "tagRenderings": [
@@ -306,7 +328,11 @@
           "hideInAnswer": true
         },
         {
-          "if": "sport=skateboard",
+          "if": {
+            "and": [
+              "sport=skateboard"
+            ]
+          },
           "then": {
             "en": "This is a skatepark",
             "nl": "Dit is een skatepark",
@@ -317,7 +343,11 @@
           }
         },
         {
-          "if": "sport=equestrian",
+          "if": {
+            "and": [
+              "sport=equestrian"
+            ]
+          },
           "then": {
             "en": "This is a horse riding arena",
             "de": "Dies ist ein Reitplatz",


### PR DESCRIPTION
This PR does 2 things in layer "sport_pitch":

### 1. Makes data filters work for skateparks and horse riding arenas

I think the data filters should have worked with the old code as well, but they didn't. I don't know why. So I changed the code as it was the case with the other sport pitches where it worked.

### 2. Adds presets for skateparks and horse riding arenas

as with table tennis tables

![mapcomplete-add-things](https://github.com/user-attachments/assets/4cd640d4-97bd-4c93-834f-3e360067647f)
